### PR TITLE
Migrate spec to Media WG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,25 @@
-# Web Platform Incubator Community Group
+# Contributing
 
-This repository is being used for work in the W3C Web Platform Incubator Community Group, governed by the [W3C Community License
-Agreement (CLA)](http://www.w3.org/community/about/agreements/cla/). To make substantive contributions,
-you must join the CG.
+Contributions to this repository are intended to become part of Recommendation-track documents
+governed by the [W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
+[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software). To contribute, you must
+either participate in the relevant W3C Working Group or make a non-member patent licensing
+ commitment.
 
 If you are not the sole contributor to a contribution (pull request), please identify all
-contributors in the pull request comment.
+contributors in the pull request's body or in subsequent comments.
 
-To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
+ To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
 
-```
-+@github_username
-```
+ ```
+ +@github_username
+ ```
 
-If you added a contributor by mistake, you can remove them in a comment with:
+ If you added a contributor by mistake, you can remove them in a comment with:
 
-```
--@github_username
-```
+ ```
+ -@github_username
+ ```
 
-If you are making a pull request on behalf of someone else but you had no part in designing the
-feature, you can remove yourself with the above syntax.
+ If you are making a pull request on behalf of someone else but you had no part in designing the
+ feature, you can remove yourself with the above syntax.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,10 +1,2 @@
-All Reports in this Repository are licensed by Contributors
-under the
-[W3C Software and Document License](http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).
-
-Contributions to Specifications are made under the
-[W3C CLA](https://www.w3.org/community/about/agreements/cla/).
-
-Contributions to Test Suites are made under the
-[W3C 3-clause BSD License](https://www.w3.org/Consortium/Legal/2008/03-bsd-license.html)
-
+All documents in this Repository are licensed by contributors under the [W3C
+Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software).

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ remote-codec-registry: codec_registry.src.html
 	                       --output codec_registry.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
-	                       -F die-on=fatal \
+	                       -F die-on=warning \
 	                       -F file=@codec_registry.src.html) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
 		echo ""; cat codec_registry.html; echo ""; \
@@ -42,7 +42,7 @@ remote-avc-codec-registration: avc_codec_registration.src.html
 	                       --output avc_codec_registration.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
-	                       -F die-on=fatal \
+	                       -F die-on=warning \
 	                       -F file=@avc_codec_registration.src.html) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
 		echo ""; cat avc_codec_registration.html; echo ""; \

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ remote-codec-registry: codec_registry.src.html
 	                       --output codec_registry.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
-	                       -F die-on=warning \
+	                       -F die-on=fatal \
 	                       -F file=@codec_registry.src.html) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
 		echo ""; cat codec_registry.html; echo ""; \
@@ -42,7 +42,7 @@ remote-avc-codec-registration: avc_codec_registration.src.html
 	                       --output avc_codec_registration.html \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
-	                       -F die-on=warning \
+	                       -F die-on=fatal \
 	                       -F file=@avc_codec_registration.src.html) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
 		echo ""; cat avc_codec_registration.html; echo ""; \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-https://wicg.github.io/web-codecs/
-
 # Try it out in Chrome 86
 
 Please see [this doc for current limitations](https://docs.google.com/document/d/1H1UHn3DIw-LOfBUdNUFR6l2-zSipXuHCVmhrwF3rR6w/edit).
@@ -13,7 +11,8 @@ https://developers.chrome.com/origintrials/#/register_trial/-7811493553674125311
 
 # WebCodecs
 
-API that allows web applications to encode and decode audio and video
+The [WebCodecs API](https://w3c.github.io/web-codecs/) allows web applications
+to encode and decode audio and video.
 
 Many Web APIs use media codecs internally to support APIs for particular uses:
 - HTMLMediaElement and Media Source Extensions
@@ -33,5 +32,5 @@ It's great for:
 - Cloud gaming
 - Media file editing and transcoding
 
-See the [explainer](https://github.com/pthatcherg/web-codecs/blob/master/explainer.md) for more info.
+See the [explainer](https://github.com/w3c/web-codecs/blob/main/explainer.md) for more info.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://developers.chrome.com/origintrials/#/register_trial/-7811493553674125311
 
 # WebCodecs
 
-The [WebCodecs API](https://w3c.github.io/web-codecs/) allows web applications
+The [WebCodecs API](https://w3c.github.io/webcodecs/) allows web applications
 to encode and decode audio and video.
 
 Many Web APIs use media codecs internally to support APIs for particular uses:
@@ -32,5 +32,5 @@ It's great for:
 - Cloud gaming
 - Media file editing and transcoding
 
-See the [explainer](https://github.com/w3c/web-codecs/blob/main/explainer.md) for more info.
+See the [explainer](https://github.com/w3c/webcodecs/blob/main/explainer.md) for more info.
 

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -5,11 +5,13 @@ Status: ED
 Shortname: webcodecs-avc-codec-registration
 Level: none
 Group: mediawg
-ED: none
+ED: https://w3c.github.io/webcodecs/avc_codec_registration.html
 Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+
 Boilerplate: omit conformance
+Text macro: NOTE yes
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for AVC (H.264), the (1) fully qualified codec strings, (2)

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -33,7 +33,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 </pre>
 
 <pre class='anchors'>
-spec: webcodecs; urlPrefix: https://wicg.github.io/web-codecs/#
+spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: attribute
         text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
     type: interface
@@ -47,14 +47,14 @@ spec: webcodecs; urlPrefix: https://wicg.github.io/web-codecs/#
 <pre class='biblio'>
 {
   "WEBCODECS": {
-      "href": "https://wicg.github.io/web-codecs/",
+      "href": "https://w3c.github.io/webcodecs/",
       "title": "WebCodecs",
-      "publisher": "WICG"
+      "publisher": "W3C"
   },
   "WEBCODECS-CODEC-REGISTRY": {
-      "href": "https://wicg.github.io/web-codecs/codec_registry.html",
+      "href": "https://w3c.github.io/webcodecs/codec_registry.html",
       "title": "WebCodecs Codec Registry",
-      "publisher": "WICG"
+      "publisher": "W3C"
   },
   "ITU-T-REC-H.264": {
     "href": "https://www.itu.int/rec/T-REC-H.264",

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -173,3 +173,10 @@ SPS and PPS are described in greater detail in sections G.3.41 and G.3.55 of
         section 5.3.3.1. This format is commonly used in .MP4 files, where the
         player generally has random access to the media data.
 </dl>
+
+Privacy and Security Considerations {#privacy-and-security-considerations}
+==========================================================================
+
+Please refer to the [[WEBCODECS#privacy-considerations|Privacy Considerations]]
+and [[WEBCODECS#security-considerations|Security Considerations]] sections in
+[[WEBCODECS]].

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -1,10 +1,10 @@
 <pre class='metadata'>
 Title: AVC (H.264) WebCodecs Registration
-Repository: wicg/web-codecs
-Status: CG-DRAFT
+Repository: w3c/webcodecs
+Status: ED
 Shortname: webcodecs-avc-codec-registration
 Level: none
-Group: wicg
+Group: mediawg
 ED: none
 Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
@@ -25,9 +25,9 @@ Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     This registration is non-normative.
 
 Markup Shorthands:css no, markdown yes, dfn yes
-!Participate: <a href="https://github.com/wicg/web-codecs">Git Repository.</a>
-!Participate: <a href="https://github.com/wicg/web-codecs/issues/new">File an issue.</a>
-!Version History: <a href="https://github.com/wicg/web-codecs/commits">https://github.com/wicg/web-codecs/commits</a>
+!Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
+!Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
 </pre>
 
 <pre class='anchors'>

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -5,12 +5,13 @@ Status: ED
 Shortname: webcodecs-codec-registry
 Level: none
 Group: mediawg
-ED: none
+ED: https://w3c.github.io/webcodecs/codec_registry.html
 Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
 Boilerplate: omit conformance
+Text macro: NOTE yes
 
 Abstract: This registry is intended to enhance interoperability among
     implementations and users of [[webcodecs]]. In particular, this

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -1,10 +1,10 @@
 <pre class='metadata'>
 Title: WebCodecs Codec Registry
-Repository: wicg/web-codecs
-Status: CG-DRAFT
+Repository: w3c/webcodecs
+Status: ED
 Shortname: webcodecs-codec-registry
 Level: none
-Group: wicg
+Group: mediawg
 ED: none
 Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
@@ -28,9 +28,9 @@ Abstract: This registry is intended to enhance interoperability among
     This registry is non-normative.
 
 Markup Shorthands:css no, markdown yes, dfn yes
-!Participate: <a href="https://github.com/wicg/web-codecs">Git Repository.</a>
-!Participate: <a href="https://github.com/wicg/web-codecs/issues/new">File an issue.</a>
-!Version History: <a href="https://github.com/wicg/web-codecs/commits">https://github.com/wicg/web-codecs/commits</a>
+!Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
+!Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
 </pre>
 
 <pre class='anchors'>
@@ -84,7 +84,7 @@ Registration Entry Requirements {#registration-entry-requirements}
     registration must link to a public specification describing how to populate
     these fields.
 4. Candidate entries must be announced by filing an issue in the
-    [WebCodecs GitHub issue tracker](https://github.com/wicg/web-codecs/issues/)
+    [WebCodecs GitHub issue tracker](https://github.com/w3c/webcodecs/issues/)
     so they can be discussed and evaluated for compliance before being added to
     the registry.
 

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -171,3 +171,10 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
     <td>TODO (string)</td>
   </tr>
 </table>
+
+Privacy and Security Considerations {#privacy-and-security-considerations}
+==========================================================================
+
+Please refer to the [[WEBCODECS#privacy-considerations|Privacy Considerations]]
+and [[WEBCODECS#security-considerations|Security Considerations]] sections in
+[[WEBCODECS]].

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -14,10 +14,10 @@ Boilerplate: omit conformance
 Text macro: NOTE yes
 
 Abstract: This registry is intended to enhance interoperability among
-    implementations and users of [[webcodecs]]. In particular, this
+    implementations and users of [[WEBCODECS]]. In particular, this
     registry provides the means to identify and avoid collisions among codec
     strings and provides a mechanism to define codec-specific members of
-    [[webcodecs]] codec configuration dictionaries.
+    [[WEBCODECS]] codec configuration dictionaries.
 
     This registry is not intended to include any information on whether a codec
     format is encumbered by intellectual property claims. Implementers and
@@ -35,7 +35,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 </pre>
 
 <pre class='anchors'>
-spec: web-codecs; urlPrefix: https://wicg.github.io/web-codecs/#
+spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: attribute
         text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
         text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
@@ -46,14 +46,14 @@ spec: web-codecs; urlPrefix: https://wicg.github.io/web-codecs/#
 <pre class='biblio'>
 {
   "WEBCODECS": {
-      "href": "https://wicg.github.io/web-codecs/",
+      "href": "https://w3c.github.io/webcodecs/",
       "title": "WebCodecs",
-      "publisher": "WICG"
+      "publisher": "W3C"
   },
   "WEBCODECS-AVC-REGISTRATION": {
-      "href": "https://wicg.github.io/web-codecs/avc_codec_registration.html",
+      "href": "https://w3c.github.io/webcodecs/avc_codec_registration.html",
       "title": "AVC (H.264) WebCodecs Registration",
-      "publisher": "WICG"
+      "publisher": "W3C"
   }
 }
 </pre>

--- a/explainer.md
+++ b/explainer.md
@@ -62,7 +62,7 @@ Core interfaces include
 
 -   **AudioFrame** contains decoded audio data. It will provide an [AudioBuffer](https://webaudio.github.io/web-audio-api/#audiobuffer) for rendering via [AudioWorklet](https://webaudio.github.io/web-audio-api/#audioworklet).
 
--   **VideoFrame** contains decoded video data. It will provide an [ImageBitmap](https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap) for manipulating in WebGL, including rendering to Canvas. It should eventually also [provide access to YUV data](https://github.com/WICG/web-codecs/issues/30), but the design is still TBD.
+-   **VideoFrame** contains decoded video data. It will provide an [ImageBitmap](https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmap) for manipulating in WebGL, including rendering to Canvas. It should eventually also [provide access to YUV data](https://github.com/w3c/webcodecs/issues/30), but the design is still TBD.
 
 -   An **AudioEncoder** encodes AudioFrames to produce EncodedAudioChunks.
 

--- a/index.src.html
+++ b/index.src.html
@@ -73,9 +73,9 @@ spec: media-capabilities; urlPrefix: https://w3c.github.io/media-capabilities/#
 <pre class='biblio'>
 {
   "WEBCODECS-CODEC-REGISTRY": {
-      "href": "https://wicg.github.io/webcodecs/codec_registry.html",
+      "href": "https://w3c.github.io/webcodecs/codec_registry.html",
       "title": "WebCodecs Codec Registry",
-      "publisher": "WICG"
+      "publisher": "W3C"
   }
 }
 </pre>

--- a/index.src.html
+++ b/index.src.html
@@ -1,9 +1,9 @@
 <pre class='metadata'>
 Title: WebCodecs
-Repository: w3c/web-codecs
+Repository: w3c/webcodecs
 Status: ED
-ED: https://w3c.github.io/web-codecs/
-Shortname: web-codecs
+ED: https://w3c.github.io/webcodecs/
+Shortname: webcodecs
 Level: None
 Group: mediawg
 Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
@@ -20,9 +20,9 @@ Abstract: This specification defines interfaces to codecs for encoding and
     codecs or none at all.
 
 Markup Shorthands:css no, markdown yes, dfn yes
-!Participate: <a href="https://github.com/w3c/web-codecs">Git Repository.</a>
-!Participate: <a href="https://github.com/w3c/web-codecs/issues/new">File an issue.</a>
-!Version History: <a href="https://github.com/w3c/web-codecs/commits">https://github.com/w3c/web-codecs/commits</a>
+!Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
+!Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
 </pre>
 
 <pre class='anchors'>
@@ -73,7 +73,7 @@ spec: media-capabilities; urlPrefix: https://w3c.github.io/media-capabilities/#
 <pre class='biblio'>
 {
   "WEBCODECS-CODEC-REGISTRY": {
-      "href": "https://wicg.github.io/web-codecs/codec_registry.html",
+      "href": "https://wicg.github.io/webcodecs/codec_registry.html",
       "title": "WebCodecs Codec Registry",
       "publisher": "WICG"
   }
@@ -1119,7 +1119,7 @@ Algorithms {#videoencoder-algorithms}
                 encode |output|. But, as written, it may occur that |output| was
                 encoded using a previous {{VideoEncoderConfig}} that has since
                 been replaced by a later call to {{VideoEncoder/configure()}}.
-                See [#138](https://github.com/w3c/web-codecs/issues/138).
+                See [#138](https://github.com/w3c/webcodecs/issues/138).
 
         2. Let |output_config| be a {{VideoDecoderConfig}} that describes
             |output|. Initialize |output_config| as follows:
@@ -2360,7 +2360,7 @@ This concern is mitigated by ensuring that input and output interfaces are
 immutable.
 
 ISSUE: EncodedVideoChunk and EncodedAudioChunk currently expose a mutable
-data. See <a href="https://github.com/w3c/web-codecs/issues/80">#80</a>.
+data. See <a href="https://github.com/w3c/webcodecs/issues/80">#80</a>.
 
 Privacy Considerations{#privacy-considerations}
 ===============================================

--- a/index.src.html
+++ b/index.src.html
@@ -1,11 +1,11 @@
 <pre class='metadata'>
 Title: WebCodecs
-Repository: wicg/web-codecs
-Status: CG-DRAFT
-ED: https://wicg.github.io/web-codecs/
+Repository: w3c/web-codecs
+Status: ED
+ED: https://w3c.github.io/web-codecs/
 Shortname: web-codecs
-Level: 1
-Group: wicg
+Level: None
+Group: mediawg
 Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
@@ -15,9 +15,9 @@ Abstract: and video. It also includes an interface for retrieving raw video
 Abstract: frames from MediaStreamStracks.
 
 Markup Shorthands:css no, markdown yes, dfn yes
-!Participate: <a href="https://github.com/wicg/web-codecs">Git Repository.</a>
-!Participate: <a href="https://github.com/wicg/web-codecs/issues/new">File an issue.</a>
-!Version History: <a href="https://github.com/wicg/web-codecs/commits">https://github.com/wicg/web-codecs/commits</a>
+!Participate: <a href="https://github.com/w3c/web-codecs">Git Repository.</a>
+!Participate: <a href="https://github.com/w3c/web-codecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/w3c/web-codecs/commits">https://github.com/w3c/web-codecs/commits</a>
 </pre>
 
 <pre class='anchors'>
@@ -1112,7 +1112,7 @@ Algorithms {#videoencoder-algorithms}
                 encode |output|. But, as written, it may occur that |output| was
                 encoded using a previous {{VideoEncoderConfig}} that has since
                 been replaced by a later call to {{VideoEncoder/configure()}}.
-                See [#138](https://github.com/WICG/web-codecs/issues/138).
+                See [#138](https://github.com/w3c/web-codecs/issues/138).
 
         2. Let |output_config| be a {{VideoDecoderConfig}} that describes
             |output|. Initialize |output_config| as follows:
@@ -2442,7 +2442,7 @@ This concern is mitigated by ensuring that input and output interfaces are
 immutable.
 
 ISSUE: EncodedVideoChunk and EncodedAudioChunk currently expose a mutable
-data. See <a href="https://github.com/WICG/web-codecs/issues/80">#80</a>.
+data. See <a href="https://github.com/w3c/web-codecs/issues/80">#80</a>.
 
 Privacy Considerations{#privacy-considerations}
 ===============================================

--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,7 @@
- {
-    "group":      [80485]
-,   "contacts":   ["yoavweiss"]
-,   "repo-type":  "cg-report"
+{
+  "group": 115198,
+  "contacts": [
+    "tidoust"
+  ],
+  "repo-type": "rec-track"
 }


### PR DESCRIPTION
**To be merged only once repo transition has happened!**

This update adjusts the metadata of the spec as it gets adopted by the Media
Working Group, and makes the following changes:

- Update CONTRIBUTING.md to match that used in W3C
- Update LICENSE.md to drop the CLA part
- Update links in README.md and to mention Media WG
- Update w3c.json
- Update status, group, and links that currently target the WICG repo in the
spec itself

Also note the switch to `Level: None` in the metadata of the spec as I suspect
that the group will publish the API without any level, at least initially.

Linked to #130.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/pull/150.html" title="Last updated on Mar 29, 2021, 8:33 AM UTC (a0aee72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-codecs/150/3f3f547...a0aee72.html" title="Last updated on Mar 29, 2021, 8:33 AM UTC (a0aee72)">Diff</a>