### PR TITLE
Make encode(frame) not auto-close its frames

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -753,9 +753,6 @@ Methods {#audioencoder-methods}
   <dd>
     [=Enqueues a control message=] to encode the given |frame|.
 
-    NOTE: This method will destroy the AudioFrame. Authors who wish to retain a
-    copy, should call `frame.clone()` prior to calling encode().
-
     When invoked, run these steps:
     1. If the value of |frame|'s {{AudioFrame/[[detached]]}} internal slot is
         `true`, throw a {{TypeError}}.
@@ -763,9 +760,8 @@ Methods {#audioencoder-methods}
         {{InvalidStateError}}.
     3. Let |frameClone| hold the result of running the [=Clone Frame=]
         algorithm with |frame|.
-    4. Destroy the original |frame| by invoking `frame.destroy()`.
-    5. Increment {{AudioEncoder/encodeQueueSize}}.
-    6. [=Queue a control message=] to encode |frameClone|.
+    4. Increment {{AudioEncoder/encodeQueueSize}}.
+    5. [=Queue a control message=] to encode |frameClone|.
 
     Running a control message to encode the frame means performing these steps.
     1. Attempt to use {{AudioEncoder/[[codec implementation]]}} to encode
@@ -1005,9 +1001,6 @@ Methods {#videoencoder-methods}
   <dd>
     [=Enqueues a control message=] to encode the given |frame|.
 
-    NOTE: This method will destroy the VideoFrame. Authors who wish to retain a
-    copy, should call `frame.clone()` prior to calling encode().
-
     When invoked, run these steps:
     1. If the value of |frame|'s {{VideoFrame/[[detached]]}} internal slot is
         `true`, throw a {{TypeError}}.
@@ -1015,9 +1008,8 @@ Methods {#videoencoder-methods}
         {{InvalidStateError}}.
     3. Let |frameClone| hold the result of running the [=Clone Frame=]
         algorithm with |frame|.
-    4. Destroy the original |frame| by invoking `frame.destroy()`.
-    5. Increment {{VideoEncoder/encodeQueueSize}}.
-    6. [=Queue a control message=] to encode |frameClone|.
+    4. Increment {{VideoEncoder/encodeQueueSize}}.
+    5. [=Queue a control message=] to encode |frameClone|.
 
     Running a control message to encode the frame means performing these steps.
     1. Attempt to use {{VideoEncoder/[[codec implementation]]}} to encode


### PR DESCRIPTION
Note: videoframe.destroy() is being renamed to close() in a follow up
change. I'll use close() to describe the change below.

This seems surprsiing in inconsistent with other APIs. Having the user
close() after calling encode is fine. Users will similarly need to close
frames coming out of the decoder or TrackProcessor.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/163.html" title="Last updated on Apr 2, 2021, 11:59 PM UTC (b34a6c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/163/4b76877...b34a6c1.html" title="Last updated on Apr 2, 2021, 11:59 PM UTC (b34a6c1)">Diff</a>