### PR TITLE
Adjust metadata following publication as FPWD

### DIFF
--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -6,7 +6,9 @@ Shortname: webcodecs-avc-codec-registration
 Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/avc_codec_registration.html
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
+TR: https://www.w3.org/TR/webcodecs-avc-codec-registration/
+Previous Version: from biblio
+Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
@@ -46,16 +48,6 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
 
 <pre class='biblio'>
 {
-  "WEBCODECS": {
-      "href": "https://w3c.github.io/webcodecs/",
-      "title": "WebCodecs",
-      "publisher": "W3C"
-  },
-  "WEBCODECS-CODEC-REGISTRY": {
-      "href": "https://w3c.github.io/webcodecs/codec_registry.html",
-      "title": "WebCodecs Codec Registry",
-      "publisher": "W3C"
-  },
   "ITU-T-REC-H.264": {
     "href": "https://www.itu.int/rec/T-REC-H.264",
     "title": "H.264 : Advanced video coding for generic audiovisual services",

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -6,7 +6,9 @@ Shortname: webcodecs-codec-registry
 Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/codec_registry.html
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
+TR: https://www.w3.org/TR/webcodecs-codec-registry/
+Previous Version: from biblio
+Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
@@ -43,20 +45,6 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
         text: AudioEncoderConfig; url: audio-encoder-config
 </pre>
 
-<pre class='biblio'>
-{
-  "WEBCODECS": {
-      "href": "https://w3c.github.io/webcodecs/",
-      "title": "WebCodecs",
-      "publisher": "W3C"
-  },
-  "WEBCODECS-AVC-REGISTRATION": {
-      "href": "https://w3c.github.io/webcodecs/avc_codec_registration.html",
-      "title": "AVC (H.264) WebCodecs Registration",
-      "publisher": "W3C"
-  }
-}
-</pre>
 
 Organization {#organization}
 ============================
@@ -158,7 +146,7 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
   <tr>
     <td>avc1.*</td>
     <td>AVC / H.264</td>
-    <td>[AVC (H.264) WebCodecs Registration](avc_codec_registration.html) [[WEBCODECS-AVC-REGISTRATION]]</td>
+    <td>[AVC (H.264) WebCodecs Registration](avc_codec_registration.html) [[WEBCODECS-AVC-CODEC-REGISTRATION]]</td>
   </tr>
   <tr>
     <td>vp8</td>

--- a/index.src.html
+++ b/index.src.html
@@ -3,10 +3,12 @@ Title: WebCodecs
 Repository: w3c/webcodecs
 Status: ED
 ED: https://w3c.github.io/webcodecs/
+TR: https://www.w3.org/TR/webcodecs/
+Previous Version: from biblio
 Shortname: webcodecs
 Level: None
 Group: mediawg
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://google.com/
+Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
@@ -68,16 +70,6 @@ spec: mediastream-recording; urlPrefix: https://www.w3.org/TR/mediastream-record
 spec: media-capabilities; urlPrefix: https://w3c.github.io/media-capabilities/#
     type: method; text: decodingInfo(); url: dom-mediacapabilities-decodinginfo
     type: attribute; text: powerEfficient; url: dom-mediacapabilitiesinfo-powerefficient
-</pre>
-
-<pre class='biblio'>
-{
-  "WEBCODECS-CODEC-REGISTRY": {
-      "href": "https://w3c.github.io/webcodecs/codec_registry.html",
-      "title": "WebCodecs Codec Registry",
-      "publisher": "W3C"
-  }
-}
 </pre>
 
 


### PR DESCRIPTION
Changes:
- Add link to the TR document
- Add link to previous version
- Drop now useless local biblio, as specs now exist in Specref. Anchors sections are still needed for now though.
- google.com is a permanent redirect to www.google.com, use the latter form to avoid the redirect.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/171.html" title="Last updated on Apr 8, 2021, 10:19 AM UTC (8f7e182)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/171/bee232d...8f7e182.html" title="Last updated on Apr 8, 2021, 10:19 AM UTC (8f7e182)">Diff</a>