### PR TITLE
Add bitrate to AudioEncoderConfig

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1481,6 +1481,7 @@ dictionary AudioEncoderConfig {
   required DOMString codec;
   unsigned long sampleRate;
   unsigned long numberOfChannels;
+  unsigned long long bitrate;
 };
 </xmp>
 </pre>
@@ -1503,6 +1504,11 @@ run these steps:
 
   <dt><dfn dict-member for=AudioEncoderConfig>numberOfChannels</dfn></dt>
   <dd>The number of audio channels.</dd>
+
+  <dt><dfn dict-member for=AudioEncoderConfig>bitrate</dfn></dt>
+  <dd>
+    The average bitrate of the encoded audio given in units of bits per second.
+  </dd>
 </dl>
 
 


### PR DESCRIPTION
Fixes #151


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/172.html" title="Last updated on Apr 9, 2021, 6:54 AM UTC (cd61686)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/172/eefd4c2...cd61686.html" title="Last updated on Apr 9, 2021, 6:54 AM UTC (cd61686)">Diff</a>