### PR TITLE
[Auto publication] Force job serialization

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -19,6 +19,8 @@ jobs:
   main:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
+      max-parallel: 1
       matrix:
         include:
           - source: index.src.html


### PR DESCRIPTION
One job runs for each of the 3 documents in the repository. Each of them updates the "gh-pages" branch. Problem is that these jobs are typically run in parallel, leading to "not up to date" issues when "git push" commands are run.

For an example of such a problem, see:
https://github.com/w3c/webcodecs/runs/2462176606

Also see discussion in:
https://github.com/w3c/spec-prod/issues/58

This update tells GitHub to serialize the jobs. Since the jobs are relatively independent otherwise, it also tells GitHub to run them to completion even when one of them fails.