### PR TITLE
Drop Previous Version link from ED

### DIFF
--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -7,7 +7,6 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/avc_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-avc-codec-registration/
-Previous Version: from biblio
 Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -7,7 +7,6 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/codec_registry.html
 TR: https://www.w3.org/TR/webcodecs-codec-registry/
-Previous Version: from biblio
 Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/

--- a/index.src.html
+++ b/index.src.html
@@ -4,7 +4,6 @@ Repository: w3c/webcodecs
 Status: ED
 ED: https://w3c.github.io/webcodecs/
 TR: https://www.w3.org/TR/webcodecs/
-Previous Version: from biblio
 Shortname: webcodecs
 Level: None
 Group: mediawg


### PR DESCRIPTION
Spec-prod attempts to override the "Previous version" link in the documents before generation with Bikeshed, but this is not a real override, leading to specs with two Previous Version links, see:
https://github.com/tabatkins/bikeshed/issues/2041

In turn, this makes publication fail when spec gets published multiple times on the same day (because "from biblio" then reports the same URL as the "This Version" link).

Dropping the "Previous version" link from the ED fixes the issue. The link is not useful in an ED in any case.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/216.html" title="Last updated on May 4, 2021, 9:34 AM UTC (da659e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/216/209a2a0...da659e4.html" title="Last updated on May 4, 2021, 9:34 AM UTC (da659e4)">Diff</a>