### PR TITLE
Add job to deploy samples to gh-pages branch

### DIFF
--- a/.github/workflows/deploy-samples.yml
+++ b/.github/workflows/deploy-samples.yml
@@ -1,0 +1,27 @@
+name: Deploy samples to gh-pages branch
+
+on:
+  push:
+    paths:
+      - 'samples/**'
+      - '.github/workflows/deploy-samples.yml'
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-20.04
+
+    steps:
+      # See doc at https://github.com/actions/checkout#checkout-v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # See doc at https://github.com/marketplace/actions/deploy-to-github-pages
+      - name: Deploy samples
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          branch: gh-pages
+          folder: samples
+          target-folder: samples


### PR DESCRIPTION
The job runs on pushes to the main branch that touch the "samples" folder and the deploy script itself. It deploys the contents of that folder to the "samples" folder in the "gh-pages" branch.

The job may also be run manually from the GitHub admin UI.
