### PR TITLE
Update sample links and add readme.md

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,6 @@
+# Samples
+
+Try out our [WebCodecs samples](https://w3c.github.io/webcodecs/samples/).
+
+Please make sure you are using the latest version of Chrome Canary to run these
+pages, as the latest API changes might not have made it to Chrome Stable.

--- a/samples/index.html
+++ b/samples/index.html
@@ -7,16 +7,16 @@
 </head>
 <body>
 <div id="container">
-  <div id="nav"><ul><li><a href="/samples">Samples</a></li></ul></div>
-  <div id="header"><h1><a href="/">WebCodecs API</a></h1></div>
+  <div id="nav"><ul><li><a href="/webcodecs/samples">Samples</a></li></ul></div>
+  <div id="header"><h1><a href="/webcodecs/">WebCodecs API</a></h1></div>
   <div id="wrapper">
     <div id="content">
-    <article onclick="window.location.href='/samples/mp4-decode/';">
-      <h1><a href="/samples/mp4-decode/">MP4 Decoding</a></h1>
+    <article onclick="window.location.href='/webcodecs/samples/mp4-decode/';">
+      <h1><a href="/webcodecs/samples/mp4-decode/">MP4 Decoding</a></h1>
       <p>Demuxes (using mp4box.js) and decodes an mp4 file.</p>
     </article>
-    <article onclick="window.location.href='/samples/image-decoder/animated-gif-renderer.html';">
-      <h1><a href="/samples/image-decoder/animated-gif-renderer.html">Animated GIF Renderer</a></h1>
+    <article onclick="window.location.href='/webcodecs/samples/image-decoder/animated-gif-renderer.html';">
+      <h1><a href="/webcodecs/samples/image-decoder/animated-gif-renderer.html">Animated GIF Renderer</a></h1>
       <p>Using ImageDecoder to implement an animated GIF renderer.</p>
     </article>
     <article onclick="window.location.href='/';">

--- a/samples/mp4-decode/index.html
+++ b/samples/mp4-decode/index.html
@@ -19,7 +19,7 @@
 
 <script type="module">
   import {MP4Demuxer} from "./mp4_demuxer.js";
-  let demuxer = new MP4Demuxer("/samples/media/bbb.mp4");
+  let demuxer = new MP4Demuxer("/webcodecs/samples/media/bbb.mp4");
 
   var canvas = document.querySelector("canvas");
   var ctx = canvas.getContext('2d');


### PR DESCRIPTION
WebCodecs is hosted at https://w3c.github.io/webcodecs/, which means that hrefs starting with '/samples/' need to start with '/webcodecs/samples/' instead.

This PR also adds a convenience link to the samples from the github /samples/readme.md.