### PR TITLE
Migrate 'webcam in worker' demo

### DIFF
--- a/samples/index.html
+++ b/samples/index.html
@@ -19,9 +19,9 @@
       <h1><a href="/webcodecs/samples/image-decoder/animated-gif-renderer.html">Animated GIF Renderer</a></h1>
       <p>Using ImageDecoder to implement an animated GIF renderer.</p>
     </article>
-    <article onclick="window.location.href='/';">
-      <h1><a href="/">Sample Demo 3</a></h1>
-      <p>A sample that shows cool WebCodecs stuff.</p>
+    <article onclick="window.location.href='/webcodecs/samples/webcam-in-worker/';">
+      <h1><a href="/webcodecs/samples/webcam-in-worker/">Webcam in worker</a></h1>
+      <p>Reading a VideoFrame Stream coming from a webcam, in a worker context.</p>
     </article>
     <article onclick="window.location.href='/';">
       <h1><a href="/">Sample Demo 4</a></h1>

--- a/samples/webcam-in-worker/index.html
+++ b/samples/webcam-in-worker/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<head>
+<title>WebCodecs webcam stream in Worker</title>
+<meta http-equiv="origin-trial" content="AlfvFCF6XVoauEvWVCLsov9cuGlQbz6aTIO6ZdLWHG5YmZpdqON+7lXo7ZUHK+IkkdkJji+7Fxnr/yTu7Iu5Og0AAABjeyJvcmlnaW4iOiJodHRwczovL3czYy5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkNvZGVjcyIsImV4cGlyeSI6MTYyNjIyMDc5OSwiaXNTdWJkb21haW4iOnRydWV9"/>
+</head>
+<video height="50%" id="vPreview" autoplay muted></video>
+<br/></br>
+<textarea id="vLog" style="width: 640px; height: 140px"></textarea>
+<br/></br>
+<button onclick="stop();">Stop</button>
+
+<script>
+var log = document.querySelector('textarea');
+var streamWorker;
+
+function stop() {
+  streamWorker.postMessage({ type: "stop" });
+}
+
+document.addEventListener('DOMContentLoaded', function(event) {
+  if (typeof MediaStreamTrackProcessor === 'undefined' ||
+      typeof MediaStreamTrackGenerator === 'undefined') {
+    log.value =
+        'Your browser does not support the experimental MediaStreamTrack API. ' +
+        'Please launch with the --enable-blink-features=WebCodecs,MediaStreamInsertableStreams flag';
+    return;
+  }
+
+  var constraints = { audio: false, video: { width: 1280, height: 720 } };
+
+  // Get a MediaStream from the webcam.
+  navigator.mediaDevices.getUserMedia(constraints).then(function(mediaStream) {
+
+    // Connect the webcam stream to the video element.
+    document.querySelector('video').srcObject = mediaStream;
+
+    // Create a new worker.
+    streamWorker = new Worker("./stream_worker.js");
+
+    // Print messages from the worker in the text area.
+    streamWorker.addEventListener('message', function(e) {
+      log.value += "Worker msg: '" + e.data + "'; ";
+    }, false);
+
+    // Create a MediaStreamTrackProcessor, which exposes frames from the track
+    // as a ReadableStream of VideoFrames.
+    var track = mediaStream.getVideoTracks()[0];
+    var processor = new MediaStreamTrackProcessor(track);
+
+
+    var frameStream = processor.readable;
+
+    // Transfer the readable stream to the worker.
+    // NOTE: transferring frameStream and reading it in the worker is more
+    // efficient than reading frameStream here and transferring VideoFrames individually.
+    streamWorker.postMessage({ type: "stream", stream: frameStream}, [frameStream]);
+
+  }).catch(function(err) { log.value += err.name + ": " + err.message; });
+}, false);
+</script>

--- a/samples/webcam-in-worker/stream_worker.js
+++ b/samples/webcam-in-worker/stream_worker.js
@@ -1,0 +1,57 @@
+var frameCount = 0
+var stopped = false;
+self.addEventListener('message', function(e) {
+
+  // In this demo, we expect at most two messages, one of each type.
+  var type = e.data.type;
+
+  if (type == "stop") {
+    stopped = true;
+    return;
+  }
+
+  if (type != "stream") {
+    console.log("Invalid message received.");
+    return;
+  }
+
+  const frameStream = e.data.stream;
+  const frameReader = frameStream.getReader();
+
+  console.log("Received stream from main page.");
+
+  frameReader.read().then(function processFrame({done, value}) {
+    if (done) {
+      self.postMessage("Stream is done");
+      return;
+    }
+
+    var frame = value;
+
+    // NOTE: all paths below must call frame.close(). Otherwise, the GC won't
+    // be fast enoug to recollect VideoFrames, and decoding can stall.
+
+    if (stopped) {
+      // TODO: There might be a more elegant way of closing a stream, or other
+      // events to listen for.
+      frameReader.releaseLock();
+      frameStream.cancel();
+
+      frame.close();
+      self.postMessage("Stream stopped");
+      return
+    }
+
+    // Processing on 'frame' goes here!
+    // E.g. this is where encoding via a VideoEncoder could be set up, or
+    // rendering to an OffscreenCanvas.
+
+    // For now, simply confirm we are receiving frames.
+    if (++frameCount % 20 == 0) {
+      self.postMessage("Read 20 frames");
+    }
+
+    frame.close();
+    frameReader.read().then(processFrame);
+  })
+}, false);


### PR DESCRIPTION
This commit migrates a demo showcasing how to transfer MediaStreamTrackProcessor's ReadableStream to a  worker. The original demo's link is:
https://tguilbert-google.github.io/webcodecs/mstp_worker/index.html