### PR TITLE
Fix WebIDL

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2719,7 +2719,7 @@ interface ImageDecoder {
   readonly attribute Promise<undefined> completed;
   readonly attribute ImageTrackList tracks;
 
-  Promise<ImageDecodeResult> decode(optional ImageDecodeOptions options);
+  Promise<ImageDecodeResult> decode(optional ImageDecodeOptions options = {});
   undefined reset();
   undefined close();
 
@@ -3345,6 +3345,7 @@ ImageTrackList Interface {#imagetracklist-interface}
 ----------------------------------------------------
 <pre class='idl'>
 <xmp>
+[Exposed=(Window,DedicatedWorker)]
 interface ImageTrackList {
   getter ImageTrack (unsigned long index);
 
@@ -3394,6 +3395,7 @@ ImageTrack Interface {#imagetrack-interface}
 --------------------------------------------
 <pre class='idl'>
 <xmp>
+[Exposed=(Window,DedicatedWorker)]
 interface ImageTrack : EventTarget {
   readonly attribute boolean animated;
   readonly attribute unsigned long frameCount;


### PR DESCRIPTION
Optional dictionary arg must have a default value of `{}`, see related text in
WebIDL in:
https://heycam.github.io/webidl/#dfn-optional-argument-default-value

"If the type of an argument is a dictionary type or a union type that has a
dictionary type as one of its flattened member types, and that dictionary type
and its ancestors have no required members, and the argument is either the final
argument or is followed only by optional arguments, then the argument must be
specified as optional and have a default value provided."

Also, interface definitions must have an "Exposed" extended attribute.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/229.html" title="Last updated on May 6, 2021, 7:07 AM UTC (d2ab661)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/229/ed5ae3c...d2ab661.html" title="Last updated on May 6, 2021, 7:07 AM UTC (d2ab661)">Diff</a>