### PR TITLE
Fix "Capture to File" sample card href

### DIFF
--- a/samples/index.html
+++ b/samples/index.html
@@ -23,7 +23,7 @@
       <h1><a href="/webcodecs/samples/webcam-in-worker/">Webcam in worker</a></h1>
       <p>Reading a VideoFrame Stream coming from a webcam, in a worker context.</p>
     </article>
-    <article onclick="window.location.href='/webcodecs/capture-to-file/capture-to-file.html';">
+    <article onclick="window.location.href='/webcodecs/samples/capture-to-file/capture-to-file.html';">
       <h1><a href="/webcodecs/samples/capture-to-file/capture-to-file.html">Capture To File</a></h1>
       <p>Reading from camera, encoding via webcodecs, and creating a webm file on disk.</p>
     </article>


### PR DESCRIPTION
The card is missing  `.../samples/...` in its href, which the title correctly has.