### PR TITLE
Remove crop* from VideoDecoderConfig

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -120,7 +120,7 @@ Definitions {#definitions}
 :: Resources including CPU memory, GPU memory, and exclusive handles to specific
     decoding/encoding hardware that may be allocated by the User Agent as part
     of codec configuration or generation of {{AudioData}} and {{VideoFrame}}
-    objects. Such resources may be quickly exhuasted and should be released
+    objects. Such resources may be quickly exhausted and should be released
     immediately when no longer in use.
 
 : <dfn>Progressive Image</dfn>
@@ -1440,6 +1440,10 @@ run these steps:
     {{VideoDecoderConfig/displayHeight}} = 0, return `false`.
 4. Return `true`.
 
+NOTE: A user agent may also reject a config whose {{VideoDecoderConfig/codedWidth}}
+  or {{VideoDecoderConfig/codedHeight}} exceeds reasonnable bounds, determined by
+  which {{VideoDecoder/[[codec implementation]]}} are available to the user agent.
+
 <dl>
   <dt><dfn dict-member for=VideoDecoderConfig>codec</dfn></dt>
   <dd>Contains a codec string describing the codec.</dd>
@@ -1465,14 +1469,19 @@ run these steps:
         adjustments.
   </dd>
 
+  NOTE: {{VideoDecoderConfig/codedWidth}} and {{VideoDecoderConfig/codedHeight}}
+    are only used as hints when selecting a {{VideoDecoder/[[codec implementation]]}}.
+
   <dt><dfn dict-member for=VideoDecoderConfig>displayWidth</dfn></dt>
   <dd>
-    Width of the VideoFrame when displayed.
+    Width of the VideoFrame when displayed. Defaults to {{VideoFrame/cropWidth}}
+    if not present.
   </dd>
 
   <dt><dfn dict-member for=VideoDecoderConfig>displayHeight</dfn></dt>
   <dd>
-    Height of the VideoFrame when displayed.
+    Height of the VideoFrame when displayed. Defaults to {{VideoFrame/cropHeight}}
+    if not present.
   </dd>
 
   <dt><dfn dict-member for=VideoDecoderConfig>hardwareAcceleration</dfn></dt>

--- a/index.src.html
+++ b/index.src.html
@@ -1495,12 +1495,8 @@ dictionary VideoDecoderConfig {
   BufferSource description;
   [EnforceRange] unsigned long codedWidth;
   [EnforceRange] unsigned long codedHeight;
-  [EnforceRange] unsigned long cropLeft;
-  [EnforceRange] unsigned long cropTop;
-  [EnforceRange] unsigned long cropWidth;
-  [EnforceRange] unsigned long cropHeight;
-  [EnforceRange] unsigned long displayWidth;
-  [EnforceRange] unsigned long displayHeight;
+  [EnforceRange] unsigned long displayAspectWidth;
+  [EnforceRange] unsigned long displayAspectHeight;
   HardwareAcceleration hardwareAcceleration = "allow";
 };
 </xmp>

--- a/index.src.html
+++ b/index.src.html
@@ -688,12 +688,12 @@ Algorithms {#videodecoder-algorithms}
             be the crop region of the decoded video frame |output| in
             pixels, prior to any aspect ratio adjustments.
         5. If |displayAspectWidth| and |displayAspectWidth| are provided,
-            assign the value of the decoded video frame in pixel to either
+            assign the value of the decoded video frame size in pixel to either
             {{VideoFramePlaneInit/displayWidth}} or
             {{VideoFramePlaneInit/displayHeight}}, and scale up the other
             dimension to match the ratio of |displayAspectWidth| and
-            |displayAspectHeight|, as described in
-            [=intrinsic width|HTMLVideoElement=].
+            |displayAspectHeight|, as described by the definitions of
+            [=intrinsic width|intrinsic size=].
         6. Otherwise, let {{VideoFramePlaneInit/displayWidth}} and
             {{VideoFramePlaneInit/displayHeight}} be the display size of
             the decoded video frame in pixels.
@@ -1486,19 +1486,19 @@ run these steps:
 
   <dt><dfn dict-member for=VideoDecoderConfig>displayAspectWidth</dfn></dt>
   <dd>
-    Width of the VideoFrame's aspect ratio when displayed.
+    Horizontal component of the VideoFrame's aspect ratio when displayed.
   </dd>
 
   <dt><dfn dict-member for=VideoDecoderConfig>displayAspectHeight</dfn></dt>
   <dd>
-    Height of the VideoFrame's aspect ratio when displayed.
+    Vertical component of the VideoFrame's aspect ratio when displayed.
   </dd>
 
-NOTE: User agents are expected to scale up a {{VideoFrame|VideoFrame's}} {{VideoFrame/displayWidth}} or
- {{VideoFrame/displayHeight}} to match the ratio of
- {{VideoDecoderConfig/displayAspectWidth}} and
- {{VideoDecoderConfig/displayAspectHeight}}, as defined in the
- [=intrinsic width|HTMLVideoElement=] spec.
+Note: {{VideoFrame/displayWidth}} and {{VideoFrame/displayHeight}} can both be
+  different from {{VideoDecoderConfig/displayAspectWidth}} and
+  {{VideoDecoderConfig/displayAspectHeight}}, but they should have identical
+  ratios, after being scaled according to defintions of
+  [=intrinsic width|intrinsic size=].
 
   <dt><dfn dict-member for=VideoDecoderConfig>hardwareAcceleration</dfn></dt>
   <dd>

--- a/index.src.html
+++ b/index.src.html
@@ -656,14 +656,15 @@ Algorithms {#videodecoder-algorithms}
         1. Let |timestamp| and |duration| be the
             {{EncodedVideoChunk/timestamp}} and {{EncodedVideoChunk/duration}}
             from the {{EncodedVideoChunk}} associated with |output|.
-        2. Let |displayAspectWidth| and |displayAspectHeight| be the
-            {{VideoDecoderConfig/displayAspectWidth}} and
-            {{VideoDecoderConfig/displayAspectHeight}} of the
-            {{VideoDecoder/[[active decoder config]]}} respectively.
-        3. Let |frame| be the result of running the [=Create a VideoFrame=]
+        2. Let |displayAspectWidth| and |displayAspectHeight| be undefined.
+        3. If {{VideoDecoderConfig/displayAspectWidth}} and
+            {{VideoDecoderConfig/displayAspectHeight}} [=map/exist=] in the
+            {{VideoDecoder/[[active decoder config]]}}, assign their values to
+            |displayAspectWidth| and |displayAspectHeight| respectively.
+        4. Let |frame| be the result of running the [=Create a VideoFrame=]
             algorithm with |output|, |timestamp|, |duration|, |displayAspectWidth|
             and |displayAspectHeight|.
-        4. Invoke {{VideoDecoder/[[output callback]]}} with |frame|.
+        5. Invoke {{VideoDecoder/[[output callback]]}} with |frame|.
   </dd>
   <dt><dfn>Reset VideoDecoder</dfn></dt>
   <dd>
@@ -1453,7 +1454,7 @@ run these steps:
   </dd>
 
   NOTE: {{VideoDecoderConfig/codedWidth}} and {{VideoDecoderConfig/codedHeight}}
-    are when selecting a {{VideoDecoder/[[codec implementation]]}}.
+    are used when selecting a {{VideoDecoder/[[codec implementation]]}}.
 
   <dt><dfn dict-member for=VideoDecoderConfig>displayAspectWidth</dfn></dt>
   <dd>

--- a/index.src.html
+++ b/index.src.html
@@ -1482,7 +1482,7 @@ run these steps:
   </dd>
 
   NOTE: {{VideoDecoderConfig/codedWidth}} and {{VideoDecoderConfig/codedHeight}}
-    are only used as hints when selecting a {{VideoDecoder/[[codec implementation]]}}.
+    are used as hints when selecting a {{VideoDecoder/[[codec implementation]]}}.
 
   <dt><dfn dict-member for=VideoDecoderConfig>displayAspectWidth</dfn></dt>
   <dd>
@@ -1497,8 +1497,8 @@ run these steps:
 Note: {{VideoFrame/displayWidth}} and {{VideoFrame/displayHeight}} can both be
   different from {{VideoDecoderConfig/displayAspectWidth}} and
   {{VideoDecoderConfig/displayAspectHeight}}, but they should have identical
-  ratios, after being scaled according to defintions of
-  [=intrinsic width|intrinsic size=].
+  ratios, after scaling is applied when
+  [=create a videoframe|creating the video frame=].
 
   <dt><dfn dict-member for=VideoDecoderConfig>hardwareAcceleration</dfn></dt>
   <dd>

--- a/index.src.html
+++ b/index.src.html
@@ -665,39 +665,6 @@ Algorithms {#videodecoder-algorithms}
             and |displayAspectHeight|.
         4. Invoke {{VideoDecoder/[[output callback]]}} with |frame|.
   </dd>
-  <dt>
-    <dfn>Create a VideoFrame</dfn> (with |output|, |timestamp|, |duration|, |displayAspectWidth|, and |displayAspectHeight|)
-  </dt>
-  <dd>
-    1. Let |planes| be a sequence of {{Plane}}s containing the decoded
-        video frame data from |output|.
-    2. Let |pixelFormat| be the {{PixelFormat}} of |planes|.
-    3. Let |init| be a {{VideoFramePlaneInit}} with the following
-        keys:
-        1. Assign |timestamp| to {{VideoFrameInit/timestamp}}.
-        2. Assign |duration| to {{VideoFrameInit/duration}}.
-        3. Let {{VideoFramePlaneInit/codedWidth}} and
-            {{VideoFramePlaneInit/codedHeight}}
-            be the width and height of the decoded video frame |output| in
-            pixels, prior to any cropping or aspect ratio adjustments.
-        4. Let {{VideoFramePlaneInit/cropLeft}},
-            {{VideoFramePlaneInit/cropTop}},
-            {{VideoFramePlaneInit/cropWidth}}, and
-            {{VideoFramePlaneInit/cropHeight}}
-            be the crop region of the decoded video frame |output| in
-            pixels, prior to any aspect ratio adjustments.
-        5. Let |displayWidth| and |displayHeight| be the the display size of
-            the decoded frame in pixels.
-        6. If |displayAspectWidth| and |displayAspectHeight| are provided,
-            increase |displayWidth| or |displayHeight| until the ratio of
-            |displayWidth| to |displayHeight| matches the ratio of
-            |displayAspectWidth| to |displayAspectHeight|.
-        7. Assign the value of |displayWidth| and |displayHeight| to
-            {{VideoFramePlaneInit/displayWidth}} and
-            {{VideoFramePlaneInit/displayHeight}} respectively.
-    4. Return a new {{VideoFrame}}, constructed with |pixelFormat|,
-        |planes|, and |init|.
-  </dd>
   <dt><dfn>Reset VideoDecoder</dfn></dt>
   <dd>
     Run these steps:
@@ -2525,6 +2492,36 @@ dictionary VideoFramePlaneInit {
     6. Assign `null` to {{VideoFrame/duration}} and {{VideoFrame/timestamp}}.
 
 ### Algorithms ###{#videoframe-algorithms}
+  <dfn>Create a VideoFrame</dfn> (with |output|, |timestamp|, |duration|, |displayAspectWidth|, and |displayAspectHeight|)
+  1. Let |planes| be a sequence of {{Plane}}s containing the decoded
+      video frame data from |output|.
+  2. Let |pixelFormat| be the {{PixelFormat}} of |planes|.
+  3. Let |init| be a {{VideoFramePlaneInit}} with the following
+      keys:
+      1. Assign |timestamp| to {{VideoFrameInit/timestamp}}.
+      2. Assign |duration| to {{VideoFrameInit/duration}}.
+      3. Let {{VideoFramePlaneInit/codedWidth}} and
+          {{VideoFramePlaneInit/codedHeight}}
+          be the width and height of the decoded video frame |output| in
+          pixels, prior to any cropping or aspect ratio adjustments.
+      4. Let {{VideoFramePlaneInit/cropLeft}},
+          {{VideoFramePlaneInit/cropTop}},
+          {{VideoFramePlaneInit/cropWidth}}, and
+          {{VideoFramePlaneInit/cropHeight}}
+          be the crop region of the decoded video frame |output| in
+          pixels, prior to any aspect ratio adjustments.
+      5. Let |displayWidth| and |displayHeight| be the the display size of
+          the decoded frame in pixels.
+      6. If |displayAspectWidth| and |displayAspectHeight| are provided,
+          increase |displayWidth| or |displayHeight| until the ratio of
+          |displayWidth| to |displayHeight| matches the ratio of
+          |displayAspectWidth| to |displayAspectHeight|.
+      7. Assign the value of |displayWidth| and |displayHeight| to
+          {{VideoFramePlaneInit/displayWidth}} and
+          {{VideoFramePlaneInit/displayHeight}} respectively.
+  4. Return a new {{VideoFrame}}, constructed with |pixelFormat|,
+      |planes|, and |init|.
+
 : To check if a {{VideoFramePlaneInit}} is a
     <dfn>valid VideoFramePlaneInit</dfn>, run these steps:
 :: 1. If {{VideoFramePlaneInit/codedWidth}} = 0 or

--- a/index.src.html
+++ b/index.src.html
@@ -54,6 +54,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
         type: dfn; text: entry settings object; url: webappapis.html#entry-settings-object
     for: media;
         type: dfn; text: current playback position; url: media.html#current-playback-position
+        type: dfn; text: intrinsic width; url: media.html#concept-video-intrinsic-width
     type: dfn; text: live; url: infrastructure.html#live
 
 spec: mediacapture-streams; urlPrefix: https://www.w3.org/TR/mediacapture-streams/
@@ -478,6 +479,8 @@ Internal Slots {#videodecoder-internal-slots}
 <dl>
 <dt><dfn attribute for=VideoDecoder>[[codec implementation]]</dfn></dt>
 <dd>Underlying decoder implementation provided by the User Agent.</dd>
+<dt><dfn attribute for=VideoDecoder>[[active decoder config]]</dfn></dt>
+<dd>The {{VideoDecoderConfig}} that is actively applied.</dd>
 <dt><dfn attribute for=VideoDecoder>[[output callback]]</dfn></dt>
 <dd>Callback given at construction for decoded outputs.</dd>
 <dt><dfn attribute for=VideoDecoder>[[error callback]]</dfn></dt>
@@ -539,7 +542,8 @@ Methods {#videodecoder-methods}
         {{VideoDecoder/[[codec implementation]]}} with an implementation
         supporting |config|.
     3. Otherwise, run the <a>Close VideoDecoder</a> algorithm with
-        {{NotSupportedError}}.
+        {{NotSupportedError}} and abort these steps.
+    4. Set {{VideoDecoder/[[active decoder config]]}} to `config`.
   </dd>
 
   <dt><dfn method for=VideoDecoder>decode(chunk)</dfn></dt>
@@ -653,12 +657,17 @@ Algorithms {#videodecoder-algorithms}
         1. Let |timestamp| and |duration| be the
             {{EncodedVideoChunk/timestamp}} and {{EncodedVideoChunk/duration}}
             from the {{EncodedVideoChunk}} associated with |output|.
-        2. Let |frame| be the result of running the [=Create a VideoFrame=]
-            algorithm with |output|, |timestamp|, and |duration|.
-        3. Invoke {{VideoDecoder/[[output callback]]}} with |frame|.
+        2. Let |displayAspectWidth| and |displayAspectHeight| be the
+            {{VideoDecoderConfig/displayAspectWidth}} and
+            {{VideoDecoderConfig/displayAspectHeight}} of the
+            {{VideoDecoder/[[active decoder config]]}} respectively.
+        3. Let |frame| be the result of running the [=Create a VideoFrame=]
+            algorithm with |output|, |timestamp|, |duration|, |displayAspectWidth|
+            and |displayAspectHeight|.
+        4. Invoke {{VideoDecoder/[[output callback]]}} with |frame|.
   </dd>
   <dt>
-    <dfn>Create a VideoFrame</dfn> (with |output|, |timestamp|, and |duration|)
+    <dfn>Create a VideoFrame</dfn> (with |output|, |timestamp|, |duration|, |displayAspectWidth|, and |displayAspectHeight|)
   </dt>
   <dd>
     1. Let |planes| be a sequence of {{Plane}}s containing the decoded
@@ -678,7 +687,14 @@ Algorithms {#videodecoder-algorithms}
             {{VideoFramePlaneInit/cropHeight}}
             be the crop region of the decoded video frame |output| in
             pixels, prior to any aspect ratio adjustments.
-        5. Let {{VideoFramePlaneInit/displayWidth}} and
+        5. If |displayAspectWidth| and |displayAspectWidth| are provided,
+            assign the value of the decoded video frame in pixel to either
+            {{VideoFramePlaneInit/displayWidth}} or
+            {{VideoFramePlaneInit/displayHeight}}, and scale up the other
+            dimension to match the ratio of |displayAspectWidth| and
+            |displayAspectHeight|, as described in
+            [=intrinsic width|HTMLVideoElement=].
+        6. Otherwise, let {{VideoFramePlaneInit/displayWidth}} and
             {{VideoFramePlaneInit/displayHeight}} be the display size of
             the decoded video frame in pixels.
     4. Return a new {{VideoFrame}}, constructed with |pixelFormat|,
@@ -1424,8 +1440,8 @@ dictionary VideoDecoderConfig {
   BufferSource description;
   unsigned long codedWidth;
   unsigned long codedHeight;
-  unsigned long displayWidth;
-  unsigned long displayHeight;
+  unsigned long displayAspectWidth;
+  unsigned long displayAspectHeight;
   HardwareAcceleration hardwareAcceleration = "allow";
 };
 </xmp>
@@ -1436,13 +1452,9 @@ run these steps:
     `false`.
 2. If {{VideoDecoderConfig/codedWidth}} = 0 or
     {{VideoDecoderConfig/codedHeight}} = 0, return `false`.
-3. If {{VideoDecoderConfig/displayWidth}} = 0 or
-    {{VideoDecoderConfig/displayHeight}} = 0, return `false`.
+3. If {{VideoDecoderConfig/displayAspectWidth}} = 0 or
+    {{VideoDecoderConfig/displayAspectWidth}} = 0, return `false`.
 4. Return `true`.
-
-NOTE: A user agent may also reject a config whose {{VideoDecoderConfig/codedWidth}}
-  or {{VideoDecoderConfig/codedHeight}} exceeds reasonnable bounds, determined by
-  which {{VideoDecoder/[[codec implementation]]}} are available to the user agent.
 
 <dl>
   <dt><dfn dict-member for=VideoDecoderConfig>codec</dfn></dt>
@@ -1472,17 +1484,21 @@ NOTE: A user agent may also reject a config whose {{VideoDecoderConfig/codedWidt
   NOTE: {{VideoDecoderConfig/codedWidth}} and {{VideoDecoderConfig/codedHeight}}
     are only used as hints when selecting a {{VideoDecoder/[[codec implementation]]}}.
 
-  <dt><dfn dict-member for=VideoDecoderConfig>displayWidth</dfn></dt>
+  <dt><dfn dict-member for=VideoDecoderConfig>displayAspectWidth</dfn></dt>
   <dd>
-    Width of the VideoFrame when displayed. Defaults to {{VideoFrame/cropWidth}}
-    if not present.
+    Width of the VideoFrame's aspect ratio when displayed.
   </dd>
 
-  <dt><dfn dict-member for=VideoDecoderConfig>displayHeight</dfn></dt>
+  <dt><dfn dict-member for=VideoDecoderConfig>displayAspectHeight</dfn></dt>
   <dd>
-    Height of the VideoFrame when displayed. Defaults to {{VideoFrame/cropHeight}}
-    if not present.
+    Height of the VideoFrame's aspect ratio when displayed.
   </dd>
+
+NOTE: User agents are expected to scale up a {{VideoFrame|VideoFrame's}} {{VideoFrame/displayWidth}} or
+ {{VideoFrame/displayHeight}} to match the ratio of
+ {{VideoDecoderConfig/displayAspectWidth}} and
+ {{VideoDecoderConfig/displayAspectHeight}}, as defined in the
+ [=intrinsic width|HTMLVideoElement=] spec.
 
   <dt><dfn dict-member for=VideoDecoderConfig>hardwareAcceleration</dfn></dt>
   <dd>

--- a/index.src.html
+++ b/index.src.html
@@ -1168,13 +1168,11 @@ Algorithms {#videoencoder-algorithms}
         2. Let |output_config| be a {{VideoDecoderConfig}} that describes
             |output|. Initialize |output_config| as follows:
             1. Assign `encoder_config.codec` to `output_config.codec`.
-            2. Assign `encoder_config.width` to `output_config.cropWidth`.
-            3. Assign `encoder_config.height` to `output_config.cropHeight`.
-            4. Assign `encoder_config.displayWidth` to
+            2. Assign `encoder_config.displayWidth` to
                 `output_config.displayWidth`.
-            5. Assign `encoder_config.displayHeight` to
+            3. Assign `encoder_config.displayHeight` to
                 `output_config.displayHeight`.
-            6. Assign the remaining keys of `output_config` as determined by
+            4. Assign the remaining keys of `output_config` as determined by
                 {{VideoEncoder/[[codec implementation]]}}. The user agent
                 must ensure that the configuration is completely described
                 such that |output_config| could be used to correctly decode
@@ -1426,10 +1424,6 @@ dictionary VideoDecoderConfig {
   BufferSource description;
   unsigned long codedWidth;
   unsigned long codedHeight;
-  unsigned long cropLeft;
-  unsigned long cropTop;
-  unsigned long cropWidth;
-  unsigned long cropHeight;
   unsigned long displayWidth;
   unsigned long displayHeight;
   HardwareAcceleration hardwareAcceleration = "allow";
@@ -1442,15 +1436,9 @@ run these steps:
     `false`.
 2. If {{VideoDecoderConfig/codedWidth}} = 0 or
     {{VideoDecoderConfig/codedHeight}} = 0, return `false`.
-3. If {{VideoDecoderConfig/cropWidth}} = 0 or {{VideoDecoderConfig/cropHeight}}
-    = 0, return `false`.
-4. If {{VideoDecoderConfig/cropTop}} + {{VideoDecoderConfig/cropHeight}} >=
-    {{VideoDecoderConfig/codedHeight}}, return `false`.
-5. If {{VideoDecoderConfig/cropLeft}} + {{VideoDecoderConfig/cropWidth}} >=
-    {{VideoDecoderConfig/codedWidth}}, return `false`.
-6. If {{VideoDecoderConfig/displayWidth}} = 0 or
+3. If {{VideoDecoderConfig/displayWidth}} = 0 or
     {{VideoDecoderConfig/displayHeight}} = 0, return `false`.
-7. Return `true`.
+4. Return `true`.
 
 <dl>
   <dt><dfn dict-member for=VideoDecoderConfig>codec</dfn></dt>
@@ -1477,40 +1465,14 @@ run these steps:
         adjustments.
   </dd>
 
-  <dt><dfn dict-member for=VideoDecoderConfig>cropLeft</dfn></dt>
-  <dd>
-    The number of pixels to remove from the left of the VideoFrame, prior to
-        aspect ratio adjustments. Defaults to zero if not present.
-  </dd>
-
-  <dt><dfn dict-member for=VideoDecoderConfig>cropTop</dfn></dt>
-  <dd>
-    The number of pixels to remove from the top of the VideoFrame, prior to
-        aspect ratio adjustments. Defaults to zero if not present.
-  </dd>
-
-  <dt><dfn dict-member for=VideoDecoderConfig>cropWidth</dfn></dt>
-  <dd>
-    The width in pixels to include in the crop, starting from cropLeft.
-        Defaults to codedWidth if not present.
-  </dd>
-
-  <dt><dfn dict-member for=VideoDecoderConfig>cropHeight</dfn></dt>
-  <dd>
-    The height in pixels to include in the crop, starting from cropLeft.
-        Defaults to codedHeight if not present.
-  </dd>
-
   <dt><dfn dict-member for=VideoDecoderConfig>displayWidth</dfn></dt>
   <dd>
-    Width of the VideoFrame when displayed. Defaults to cropWidth if not
-        present.
+    Width of the VideoFrame when displayed.
   </dd>
 
   <dt><dfn dict-member for=VideoDecoderConfig>displayHeight</dfn></dt>
   <dd>
-    Height of the VideoFrame when displayed. Defaults to cropHeight if not
-        present.
+    Height of the VideoFrame when displayed.
   </dd>
 
   <dt><dfn dict-member for=VideoDecoderConfig>hardwareAcceleration</dfn></dt>

--- a/index.src.html
+++ b/index.src.html
@@ -54,7 +54,6 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
         type: dfn; text: entry settings object; url: webappapis.html#entry-settings-object
     for: media;
         type: dfn; text: current playback position; url: media.html#current-playback-position
-        type: dfn; text: intrinsic width; url: media.html#concept-video-intrinsic-width
     type: dfn; text: live; url: infrastructure.html#live
 
 spec: mediacapture-streams; urlPrefix: https://www.w3.org/TR/mediacapture-streams/
@@ -687,16 +686,15 @@ Algorithms {#videodecoder-algorithms}
             {{VideoFramePlaneInit/cropHeight}}
             be the crop region of the decoded video frame |output| in
             pixels, prior to any aspect ratio adjustments.
-        5. If |displayAspectWidth| and |displayAspectWidth| are provided,
-            assign the value of the decoded video frame size in pixel to either
-            {{VideoFramePlaneInit/displayWidth}} or
-            {{VideoFramePlaneInit/displayHeight}}, and scale up the other
-            dimension to match the ratio of |displayAspectWidth| and
-            |displayAspectHeight|, as described by the definitions of
-            [=intrinsic width|intrinsic size=].
-        6. Otherwise, let {{VideoFramePlaneInit/displayWidth}} and
-            {{VideoFramePlaneInit/displayHeight}} be the display size of
-            the decoded video frame in pixels.
+        5. Let |displayWidth| and |displayHeight| be the the display size of
+            the decoded frame in pixels.
+        6. If |displayAspectWidth| and |displayAspectHeight| are provided,
+            increase |displayWidth| or |displayHeight| until the ratio of
+            |displayWidth| to |displayHeight| matches the ratio of
+            |displayAspectWidth| to |displayAspectHeight|.
+        7. Assign the value of |displayWidth| and |displayHeight| to
+            {{VideoFramePlaneInit/displayWidth}} and
+            {{VideoFramePlaneInit/displayHeight}} respectively.
     4. Return a new {{VideoFrame}}, constructed with |pixelFormat|,
         |planes|, and |init|.
   </dd>
@@ -1450,11 +1448,17 @@ To check if a {{VideoDecoderConfig}} is a <dfn>valid VideoDecoderConfig</dfn>,
 run these steps:
 1. If {{VideoDecoderConfig/codec}} is not a <a>valid codec string</a>, return
     `false`.
-2. If {{VideoDecoderConfig/codedWidth}} = 0 or
+2. If one of {{VideoDecoderConfig/codedWidth}} or
+    {{VideoDecoderConfig/codedHeight}} is provided but the other isn't,
+    return `false`.
+3. If {{VideoDecoderConfig/codedWidth}} = 0 or
     {{VideoDecoderConfig/codedHeight}} = 0, return `false`.
-3. If {{VideoDecoderConfig/displayAspectWidth}} = 0 or
-    {{VideoDecoderConfig/displayAspectWidth}} = 0, return `false`.
-4. Return `true`.
+4. If one of {{VideoDecoderConfig/displayAspectWidth}} or
+    {{VideoDecoderConfig/displayAspectHeight}} is provided but the other isn't,
+    return `false`.
+5. If {{VideoDecoderConfig/displayAspectWidth}} = 0 or
+    {{VideoDecoderConfig/displayAspectHeight}} = 0, return `false`.
+6. Return `true`.
 
 <dl>
   <dt><dfn dict-member for=VideoDecoderConfig>codec</dfn></dt>
@@ -1482,16 +1486,16 @@ run these steps:
   </dd>
 
   NOTE: {{VideoDecoderConfig/codedWidth}} and {{VideoDecoderConfig/codedHeight}}
-    are used as hints when selecting a {{VideoDecoder/[[codec implementation]]}}.
+    are when selecting a {{VideoDecoder/[[codec implementation]]}}.
 
   <dt><dfn dict-member for=VideoDecoderConfig>displayAspectWidth</dfn></dt>
   <dd>
-    Horizontal component of the VideoFrame's aspect ratio when displayed.
+    Horizontal dimension of the VideoFrame's aspect ratio when displayed.
   </dd>
 
   <dt><dfn dict-member for=VideoDecoderConfig>displayAspectHeight</dfn></dt>
   <dd>
-    Vertical component of the VideoFrame's aspect ratio when displayed.
+    Vertical dimension of the VideoFrame's aspect ratio when displayed.
   </dd>
 
 Note: {{VideoFrame/displayWidth}} and {{VideoFrame/displayHeight}} can both be


### PR DESCRIPTION
VideoDecoderConfig's cropHeight, cropWidth, cropTop and cropLeft are all deprecated, and need to be removed.

Remaining references to crop* on VideoFrame and VideoFramePlaneInit will be removed in upcoming PRs dealing with VisibleRegions.

This should address issue #94.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tguilbert-google/webcodecs/pull/250.html" title="Last updated on May 26, 2021, 10:12 PM UTC (48e8fdb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/250/0db2aae...tguilbert-google:48e8fdb.html" title="Last updated on May 26, 2021, 10:12 PM UTC (48e8fdb)">Diff</a>