### PR TITLE
Fix semi-broken link to AVC WebCodecs Registration

### DIFF
--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -147,7 +147,7 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
   <tr>
     <td>avc1.*</td>
     <td>AVC / H.264</td>
-    <td>[AVC (H.264) WebCodecs Registration](avc_codec_registration.html) [[WEBCODECS-AVC-CODEC-REGISTRATION]]</td>
+    <td>[AVC (H.264) WebCodecs Registration](https://www.w3.org/TR/webcodecs-avc-codec-registration/) [[WEBCODECS-AVC-CODEC-REGISTRATION]]</td>
   </tr>
   <tr>
     <td>vp8</td>


### PR DESCRIPTION
The link to the AVC spec is fine in the ED of the registry spec, but breaks when the spec is published to /TR because the AVC spec gets published to a different folder.

This update switches link to use an absolute URL.