### PR TITLE
Leave duration unsigned long long.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1937,8 +1937,8 @@ EncodedVideoChunk Interface{#encodedvideochunk-interface}
 interface EncodedVideoChunk {
   constructor(EncodedVideoChunkInit init);
   readonly attribute EncodedVideoChunkType type;
-  readonly attribute long long timestamp;    // microseconds
-  readonly attribute long long? duration;    // microseconds
+  readonly attribute long long timestamp;             // microseconds
+  readonly attribute unsigned long long? duration;    // microseconds
   readonly attribute unsigned long byteLength;
 
   undefined copyTo(ArrayBufferView dst);
@@ -1946,8 +1946,8 @@ interface EncodedVideoChunk {
 
 dictionary EncodedVideoChunkInit {
   required EncodedVideoChunkType type;
-  [EnforceRange] required long long timestamp;    // microseconds
-  [EnforceRange] long long duration;              // microseconds
+  [EnforceRange] required long long timestamp;        // microseconds
+  [EnforceRange] unsigned long long duration;         // microseconds
   required BufferSource data;
 };
 
@@ -2053,8 +2053,8 @@ interface AudioData {
   readonly attribute float sampleRate;
   readonly attribute unsigned long numberOfFrames;
   readonly attribute unsigned long numberOfChannels;
-  readonly attribute long long duration;     // microseconds
-  readonly attribute long long timestamp;    // microseconds
+  readonly attribute unsigned long long duration;  // microseconds
+  readonly attribute long long timestamp;          // microseconds
 
   unsigned long allocationSize(AudioDataCopyToOptions options);
   undefined copyTo([AllowShared] BufferSource destination, AudioDataCopyToOptions options);
@@ -2067,7 +2067,7 @@ dictionary AudioDataInit {
   [EnforceRange] required float sampleRate;
   [EnforceRange] required unsigned long numberOfFrames;
   [EnforceRange] required unsigned long numberOfChannels;
-  [EnforceRange] required long long timestamp;    // microseconds
+  [EnforceRange] required long long timestamp;  // microseconds
   required BufferSource data;
 };
 </xmp>
@@ -2462,16 +2462,16 @@ interface VideoFrame {
   readonly attribute unsigned long cropHeight;
   readonly attribute unsigned long displayWidth;
   readonly attribute unsigned long displayHeight;
-  readonly attribute long long? duration;     // microseconds
-  readonly attribute long long? timestamp;    // microseconds
+  readonly attribute unsigned long long? duration;  // microseconds
+  readonly attribute long long? timestamp;          // microseconds
 
   VideoFrame clone();
   undefined close();
 };
 
 dictionary VideoFrameInit {
-  long long duration;     // microseconds
-  long long timestamp;    // microseconds
+  unsigned long long duration;  // microseconds
+  long long timestamp;          // microseconds
 };
 
 dictionary VideoFramePlaneInit {
@@ -2484,8 +2484,8 @@ dictionary VideoFramePlaneInit {
   [EnforceRange] unsigned long cropHeight;
   [EnforceRange] unsigned long displayWidth;
   [EnforceRange] unsigned long displayHeight;
-  [EnforceRange] long long duration;     // microseconds
-  [EnforceRange] long long timestamp;    // microseconds
+  [EnforceRange] unsigned long long duration;  // microseconds
+  [EnforceRange] long long timestamp;          // microseconds
 };
 </xmp>
 


### PR DESCRIPTION
Earlier PR to make timestamp signed long long got a little carried away and changed duration as well. The two should both be long long microseconds, but only timestamp should be signed (negative duration isn't a thing).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/262.html" title="Last updated on Jun 2, 2021, 4:43 AM UTC (2f32ac4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/262/7730b88...2f32ac4.html" title="Last updated on Jun 2, 2021, 4:43 AM UTC (2f32ac4)">Diff</a>