### PR TITLE
Make Encoded*Chunk.copyTo(...) accept [AllowShared]BufferSource

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1882,7 +1882,7 @@ interface EncodedAudioChunk {
   readonly attribute long long timestamp;    // microseconds
   readonly attribute unsigned long byteLength;
 
-  undefined copyTo(ArrayBufferView dst);
+  undefined copyTo([AllowShared] BufferSource destination);
 };
 
 dictionary EncodedAudioChunkInit {
@@ -1923,12 +1923,11 @@ enum EncodedAudioChunkType {
 :: The byte length of {{EncodedAudioChunk/[[internal data]]}}.
 
 ### Methods ###{#encodedaudiochunk-methods}
-: <dfn method for=EncodedAudioChunk>copyTo(dst)</dfn>
+: <dfn method for=EncodedAudioChunk>copyTo(destination)</dfn>
 :: When invoked, run these steps:
     1. If {{EncodedAudioChunk/byteLength}} is greater than
-        |dst|.`byteLength`,
-        throw a {{TypeError}}.
-    2. Copy the {{EncodedAudioChunk/[[internal data]]}} into |dst|.
+        |destination|.`byteLength`, throw a {{TypeError}}.
+    2. Copy the {{EncodedAudioChunk/[[internal data]]}} into |destination|.
 
 EncodedVideoChunk Interface{#encodedvideochunk-interface}
 -----------------------------------------------------------
@@ -1941,7 +1940,7 @@ interface EncodedVideoChunk {
   readonly attribute long long? duration;    // microseconds
   readonly attribute unsigned long byteLength;
 
-  undefined copyTo(ArrayBufferView dst);
+  undefined copyTo([AllowShared] BufferSource destination);
 };
 
 dictionary EncodedVideoChunkInit {
@@ -1989,12 +1988,11 @@ enum EncodedVideoChunkType {
 :: The byte length of {{EncodedVideoChunk/[[internal data]]}}.
 
 ### Methods ###{#encodedvideochunk-methods}
-: <dfn method for=EncodedVideoChunk>copyTo(dst)</dfn>
+: <dfn method for=EncodedVideoChunk>copyTo(destination)</dfn>
 :: When invoked, run these steps:
     1. If {{EncodedVideoChunk/byteLength}} is greater than
-        |dst|.`byteLength`,
-        throw a {{TypeError}}.
-    2. Copy the {{EncodedVideoChunk/[[internal data]]}} into |dst|.
+        |destination|.`byteLength`, throw a {{TypeError}}.
+    2. Copy the {{EncodedVideoChunk/[[internal data]]}} into |destination|.
 
 
 Raw Media Interfaces {#raw-media-interfaces}


### PR DESCRIPTION
Matches what was done for AudioData. No reason not to allow the broader BufferSource union, including SharedArrayBuffer.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/263.html" title="Last updated on Jun 2, 2021, 4:52 AM UTC (3b6a72b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/263/7730b88...3b6a72b.html" title="Last updated on Jun 2, 2021, 4:52 AM UTC (3b6a72b)">Diff</a>