### PR TITLE
Rename AudioData.sampleFormat -> AudioData.format to match VideoFrame

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -453,7 +453,7 @@ Algorithms {#audiodecoder-algorithms}
             5. Let |timestamp| be the {{EncodedAudioChunk/timestamp}} of the
                 {{EncodedAudioChunk}} associated with |output|.
             6. Assign |timestamp| to {{AudioData/[[timestamp]]}}.
-            7. Assign values to {{AudioData/[[sample format]]}},
+            7. Assign values to {{AudioData/[[format]]}},
                 {{AudioData/[[sample rate]]}},
                 {{AudioData/[[number of frames]]}}, and
                 {{AudioData/[[number of channels]]}} as determined by |output|.
@@ -2049,7 +2049,7 @@ AudioData Interface {#audiodata-interface}
 interface AudioData {
   constructor(AudioDataInit init);
 
-  readonly attribute AudioSampleFormat sampleFormat;
+  readonly attribute AudioSampleFormat format;
   readonly attribute float sampleRate;
   readonly attribute unsigned long numberOfFrames;
   readonly attribute unsigned long numberOfChannels;
@@ -2063,7 +2063,7 @@ interface AudioData {
 };
 
 dictionary AudioDataInit {
-  required AudioSampleFormat sampleFormat;
+  required AudioSampleFormat format;
   [EnforceRange] required float sampleRate;
   [EnforceRange] required unsigned long numberOfFrames;
   [EnforceRange] required unsigned long numberOfChannels;
@@ -2081,7 +2081,7 @@ dictionary AudioDataInit {
 :: A reference to a [=media resource=] that stores the audio sample data for
     this {{AudioData}}.
 
-: <dfn attribute for=AudioData>[[sample format]]</dfn>
+: <dfn attribute for=AudioData>\[[format]]</dfn>
 :: The {{AudioSampleFormat}} used by this {{AudioData}}.
 
 : <dfn attribute for=AudioData>[[sample rate]]</dfn>
@@ -2102,8 +2102,8 @@ dictionary AudioDataInit {
 </dfn>
 1. Let |frame| be a new {{AudioData}} object, initialized as follows:
     1. Assign `false` to {{AudioData/[[detached]]}}.
-    2. Assign |init|.{{AudioDataInit/sampleFormat}} to
-        {{AudioData/[[sample format]]}}.
+    2. Assign |init|.{{AudioDataInit/format}} to
+        {{AudioData/[[format]]}}.
     3. Assign |init|.{{AudioDataInit/sampleRate}} to
         {{AudioData/[[sample rate]]}}.
     4. Assign |init|.{{AudioDataInit/numberOfFrames}} to
@@ -2120,11 +2120,11 @@ dictionary AudioDataInit {
 
 ### Attributes ###{#audiodata-attributes}
 
-: <dfn attribute for=AudioData>sampleFormat</dfn>
+: <dfn attribute for=AudioData>format</dfn>
 :: The {{AudioSampleFormat}} used by this {{AudioData}}.
 
-    The {{AudioData/sampleFormat}} getter steps are to return
-    {{AudioData/[[sample format]]}}.
+    The {{AudioData/format}} getter steps are to return
+    {{AudioData/[[format]]}}.
 
 : <dfn attribute for=AudioData>sampleRate</dfn>
 :: The sample-rate, in Hz, for this {{AudioData}}.
@@ -2168,7 +2168,7 @@ dictionary AudioDataInit {
     1. Let |copyElementCount| be the result of running the
         [=Compute Copy Element Count=] algorithm with |options|.
     2. Let |bytesPerSample| be the number of bytes per sample, as defined by
-        the {{AudioData/[[sample format]]}}.
+        the {{AudioData/[[format]]}}.
     3. Return the product of multiplying |bytesPerSample| by
         |copyElementCount|.
 
@@ -2182,7 +2182,7 @@ dictionary AudioDataInit {
     2. Let |copyElementCount| be the result of running the
         [=Compute Copy Element Count=] algorithm with |options|.
     3. Let |bytesPerSample| be the number of bytes per sample, as defined by
-        the {{AudioData/[[sample format]]}}.
+        the {{AudioData/[[format]]}}.
     4. If the product of multiplying |bytesPerSample| by |copyElementCount| is
         greater than `destination.byteLength`, throw a {{RangeError}}.
     5. Let |resource| be the [=media resource=] referenced by
@@ -2226,7 +2226,7 @@ dictionary AudioDataInit {
         2. Otherwise, assign |options|.{{AudioDataCopyToOptions/frameCount}}
             to |copyFrameCount|.
     5. Let |elementCount| be |copyFrameCount|.
-    6. If {{AudioData/[[sample format]]}} describes an interleaved
+    6. If {{AudioData/[[format]]}} describes an interleaved
         {{AudioSampleFormat}}, mutliply |elementCount| by
         {{AudioData/[[number of channels]]}}
     7. return |elementCount|.
@@ -2239,7 +2239,7 @@ dictionary AudioDataInit {
         2. Let |reference| be a new reference to |resource|.
         3. Assign |reference| to {{AudioData/[[resource reference]]}}.
         4. Assign the values of |data|'s {{AudioData/[[detached]]}},
-            {{AudioData/[[sample format]]}}, {{AudioData/[[sample rate]]}},
+            {{AudioData/[[format]]}}, {{AudioData/[[sample rate]]}},
             {{AudioData/[[number of frames]]}},
             {{AudioData/[[number of channels]]}}, and
             {{AudioData/[[timestamp]]}} slots to the corresponding slots in


### PR DESCRIPTION
Matching VideoFrame is good. Sample format is more to type and the meaning of 'format' seems pretty intuitive given the context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/264.html" title="Last updated on Jun 2, 2021, 4:58 AM UTC (d14b5a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/264/7730b88...d14b5a4.html" title="Last updated on Jun 2, 2021, 4:58 AM UTC (d14b5a4)">Diff</a>