### PR TITLE
Move SVC data to its own dictionnary

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1358,9 +1358,9 @@ Algorithms {#videoencoder-algorithms}
                 {{VideoEncoder/[[active output config]]}}.
         7. If |encoderConfig|.{{VideoEncoderConfig/scalabilityMode}}
             describes multiple [=temporal layers=]:
-            1. Let |temporal_layer_id| be the zero-based index describing the
+            1. Let |svc| be a new {{SvcOutputMetadata}} instance.
+            2. Let |temporal_layer_id| be the zero-based index describing the
                 temporal layer for |output|.
-            2. Let |svc| be a new {{SvcOutputMetadata}} instance.
             3. Assign |temporal_layer_id| to
                 |svc|.{{SvcOutputMetadata/temporalLayerId}}.
             4. Assign |svc| to
@@ -1417,7 +1417,8 @@ dictionary SvcOutputMetadata {
     {{EncodedVideoChunk}}.
 
 : <dfn dict-member for=EncodedVideoChunkMetadata>svc</dfn>
-:: A collection of metadata related to the {{EncodedVideoChunk}}'s SVC options.
+:: A collection of metadata describing this {{EncodedVideoChunk}} with respect
+    to the configured {{VideoEncoderConfig/scalabilityMode}}.
 
 : <dfn dict-member for=SvcOutputMetadata>temporalLayerId</dfn>
 :: A number that identifies the [=temporal layer=] for the associated

--- a/index.src.html
+++ b/index.src.html
@@ -1360,8 +1360,11 @@ Algorithms {#videoencoder-algorithms}
             describes multiple [=temporal layers=]:
             1. Let |temporal_layer_id| be the zero-based index describing the
                 temporal layer for |output|.
-            2. Assign |temporal_layer_id| to
-                |chunkMetadata|.{{EncodedVideoChunkMetadata/temporalLayerId}}.
+            2. Let |svc| be a new {{SvcOutputMetadata}} instance.
+            3. Assign |temporal_layer_id| to
+                |svc|.{{SvcOutputMetadata/temporalLayerId}}.
+            4. Assign |svc| to
+                |chunkMetadata|.{{EncodedVideoChunkMetadata/svc}}.
         8. Invoke {{VideoEncoder/[[output callback]]}} with |chunk| and
             |chunkMetadata|.
   </dd>
@@ -1401,6 +1404,10 @@ The following metadata dictionary is emitted by the
 <xmp class='idl'>
 dictionary EncodedVideoChunkMetadata {
   VideoDecoderConfig decoderConfig;
+  SvcOutputMetadata svc;
+};
+
+dictionary SvcOutputMetadata {
   unsigned long temporalLayerId;
 };
 </xmp>
@@ -1409,7 +1416,10 @@ dictionary EncodedVideoChunkMetadata {
 :: A {{VideoDecoderConfig}} that authors may use to decode the associated
     {{EncodedVideoChunk}}.
 
-: <dfn dict-member for=EncodedVideoChunkMetadata>temporalLayerId</dfn>
+: <dfn dict-member for=EncodedVideoChunkMetadata>svc</dfn>
+:: A collection of metadata related to the {{EncodedVideoChunk}}'s SVC options.
+
+: <dfn dict-member for=SvcOutputMetadata>temporalLayerId</dfn>
 :: A number that identifies the [=temporal layer=] for the associated
     {{EncodedVideoChunk}}.
 


### PR DESCRIPTION
This PR moves the `temporalLayerId` into a dedicated `svc` dictionary, freeing up the top level `EncodedVideoChunkMetadata` object.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tguilbert-google/webcodecs/pull/283.html" title="Last updated on Jun 17, 2021, 6:30 PM UTC (d72fc4f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/283/a96a6d7...tguilbert-google:d72fc4f.html" title="Last updated on Jun 17, 2021, 6:30 PM UTC (d72fc4f)">Diff</a>