### PR TITLE
Define some pixel formats

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3325,6 +3325,8 @@ enum PixelFormat {
   "I420",
   // 4:2:0 Y, U, V, A
   "I420A",
+  // 4:2:2 Y, U, V
+  "I422",
 };
 </xmp>
 
@@ -3380,6 +3382,32 @@ enum PixelFormat {
     The {{VideoFrame/codedWidth}} and {{VideoFrame/codedHeight}} MUST be even.
     Similarly, the visible rectangle ({{VideoFrame/displayWidth}} and
     {{VideoFrame/displayHeight}}) MUST be even.
+  </dd>
+  <dt><dfn enum-value for=PixelFormat>I422</dfn></dt>
+  <dd>
+
+    This format is composed of three distinct planes, one plane of Luma and two
+    planes of Chroma, denoted Y, U and V, and present in this order. It is also
+    often refered to as Planar YUV 4:2:2.
+
+    The U an V planes are sub-sampled horizontaly by a factor of 2 compared to
+    the Y planes.
+
+    Each sample in this format is 8 bits.
+
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} samples (and
+    therefore bytes) in the Y plane, arranged starting at the top left in the
+    image, in {{VideoFrame/codedHeight}} lines of {{VideoFrame/codedWidth}}
+    samples.
+
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} / 2 samples
+    (and therefore bytes) in the two U and V planes, arranged starting at the
+    top left in the image, in {{VideoFrame/codedHeight}} / 2 lines of
+    {{VideoFrame/codedWidth}} samples.
+
+    The {{VideoFrame/codedHeight}} MUST be even.  Similarly, the crop
+    coordinates ({{VideoFrame/displayWidth}} and {{VideoFrame/displayHeight}})
+    MUST be even.
   </dd>
 </dl>
 

--- a/index.src.html
+++ b/index.src.html
@@ -3323,6 +3323,8 @@ number and order of the planes. Each format is described in its own sub-section.
 enum PixelFormat {
   // 4:2:0 Y, U, V
   "I420",
+  // 4:2:0 Y, U, V, A
+  "I420A",
 };
 </xmp>
 
@@ -3344,6 +3346,33 @@ enum PixelFormat {
     samples.
 
     There is {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} / 4 samples
+    (and therefore bytes) in the two U and V planes, arranged starting at the
+    top left in the image, in {{VideoFrame/codedHeight}} / 2 lines of
+    {{VideoFrame/codedWidth}} / 2 samples.
+
+    The {{VideoFrame/codedWidth}} and {{VideoFrame/codedHeight}} MUST be even.
+    Similarly, the visible rectangle ({{VideoFrame/displayWidth}} and
+    {{VideoFrame/displayHeight}}) MUST be even.
+  </dd>
+  <dt><dfn enum-value for=PixelFormat>I420A</dfn></dt>
+  <dd>
+
+    This format is composed of four distinct planes, one plane of Luma, two
+    planes of Chroma, denoted Y, U and V, and one place of alpha values, all
+    present in this order. It is also often refered to as Planar YUV 4:2:0 with
+    an alpha channel.
+
+    The U an V planes are sub-sampled horizontaly and vertically by a factor of
+    2 compared to the Y and Alpha planes.
+
+    Each sample in this format is 8 bits.
+
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} samples (and
+    therefore bytes) in the Y and alpha plane, arranged starting at the top left
+    in the image, in {{VideoFrame/codedHeight}} lines of
+    {{VideoFrame/codedWidth}} samples.
+
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} / 4 samples
     (and therefore bytes) in the two U and V planes, arranged starting at the
     top left in the image, in {{VideoFrame/codedHeight}} / 2 lines of
     {{VideoFrame/codedWidth}} / 2 samples.

--- a/index.src.html
+++ b/index.src.html
@@ -3333,6 +3333,8 @@ enum PixelFormat {
   "NV12",
   // 32bpp RGBA
   "RGBA",
+  // 32bpp RGBX (opaque)
+  "RGBX",
 };
 </xmp>
 
@@ -3497,6 +3499,20 @@ enum PixelFormat {
     There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} * 4 samples
     (and therefore bytes) in the single plane, arranged starting at the top
     left in the image, in {{VideoFrame/codedHeight}} lines of
+    {{VideoFrame/codedWidth}} samples.
+  </dd>
+  <dt><dfn enum-value for=PixelFormat>RGBX</dfn></dt>
+  <dd>
+
+    This format is composed of a single plane, that encodes four components:
+    Red, Green, Blue, and a padding value, present in this order.
+
+    Each sample in this format is 8 bits. The fourth element in each pixel is to
+    be ignored, the image is always fully opaque.
+
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} * 4 samples
+    (and therefore bytes) in the single plane, arranged starting at the top left
+    in the image, in {{VideoFrame/codedHeight}} lines of
     {{VideoFrame/codedWidth}} samples.
   </dd>
 </dl>

--- a/index.src.html
+++ b/index.src.html
@@ -3331,6 +3331,8 @@ enum PixelFormat {
   "I444",
   // 4:2:0 Y, UV
   "NV12",
+  // 32bpp RGBA
+  "RGBA",
 };
 </xmp>
 
@@ -3483,6 +3485,19 @@ enum PixelFormat {
 
     All samples being linear in memory.
   </div>
+  </dd>
+  <dt><dfn enum-value for=PixelFormat>RGBA</dfn></dt>
+  <dd>
+
+    This format is composed of a single plane, that encodes four components:
+    Red, Green, Blue, and an alpha value, present in this order.
+
+    Each sample in this format is 8 bits, and each pixel is therefore 32 bits.
+
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} * 4 samples
+    (and therefore bytes) in the single plane, arranged starting at the top
+    left in the image, in {{VideoFrame/codedHeight}} lines of
+    {{VideoFrame/codedWidth}} samples.
   </dd>
 </dl>
 

--- a/index.src.html
+++ b/index.src.html
@@ -3329,6 +3329,8 @@ enum PixelFormat {
   "I422",
   // 4:4:4 Y, U, V
   "I444",
+  // 4:2:0 Y, UV
+  "NV12",
 };
 </xmp>
 
@@ -3425,6 +3427,62 @@ enum PixelFormat {
     therefore bytes) in all three planes, arranged starting at the top left in the
     image, in {{VideoFrame/codedHeight}} lines of {{VideoFrame/codedWidth}}
     samples.
+  </dd>
+  <dt><dfn enum-value for=PixelFormat>NV12</dfn></dt>
+  <dd>
+
+    This format is composed of two distinct planes, one plane of Luma and then
+    another plane for the two Chroma components. The two planes are present in
+    this order, and are refered to as respectively the Y plane and the UV plane.
+
+    The U an V components are sub-sampled horizontaly and vertically by a factor
+    of 2 compared to the components in the Y planes.
+
+    Each sample in this format is 8 bits.
+
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} samples (and
+    therefore bytes) in the Y plane, arranged starting at the top left in the
+    image, in {{VideoFrame/codedHeight}} lines of {{VideoFrame/codedWidth}}
+    samples.
+
+    The UV planes is composed of interleaved U and V values, in
+    {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} / 4 elements (of two
+    bytes each), arranged starting at the top left in the image, in
+    {{VideoFrame/codedHeight}} / 2 lines of {{VideoFrame/codedWidth}} / 2
+    elements. Each element is composed of a two Chroma values, the U and V
+    value, in this order.
+
+    The {{VideoFrame/codedWidth}} and {{VideoFrame/codedHeight}} MUST be even.
+    Similarly, the visible rectangle ({{VideoFrame/displayWidth}} and
+    {{VideoFrame/displayHeight}}) MUST be even.
+
+    <div class=example>
+    An image in the NV12 pixel format that is 16 pixels wide and 9 pixels tall
+    will be arranged like so in memory:
+
+    ```
+        YYYYYYYYYYYYYY
+        YYYYYYYYYYYYYY
+        YYYYYYYYYYYYYY
+        YYYYYYYYYYYYYY
+        YYYYYYYYYYYYYY
+        YYYYYYYYYYYYYY
+        YYYYYYYYYYYYYY
+        YYYYYYYYYYYYYY
+        YYYYYYYYYYYYYY
+        UVUVUVUVUVUVUV
+        UVUVUVUVUVUVUV
+        UVUVUVUVUVUVUV
+        UVUVUVUVUVUVUV
+        UVUVUVUVUVUVUV
+        UVUVUVUVUVUVUV
+        UVUVUVUVUVUVUV
+        UVUVUVUVUVUVUV
+        UVUVUVUVUVUVUV
+    ```
+
+    All samples being linear in memory.
+  </div>
   </dd>
 </dl>
 

--- a/index.src.html
+++ b/index.src.html
@@ -3317,27 +3317,42 @@ dictionary PlaneLayout {
 Pixel Format{#pixel-format}
 ---------------------------
 Pixel formats describe the arrangement of bytes in each plane as well as the
-number and order of the planes.
-
-NOTE: This section needs work. We expect to add more pixel formats and offer
-    much more verbose definitions. For now, please see
-    <a href="http://www.fourcc.org/pixel-format/yuv-i420/">
-    http://www.fourcc.org/pixel-format/yuv-i420/</a> for a more complete
-    description.
+number and order of the planes. Each format is described in its own sub-section.
 
 <xmp class='idl'>
 enum PixelFormat {
-  "I420"
+  // 4:2:0 Y, U, V
+  "I420",
 };
 </xmp>
 
 <dl>
   <dt><dfn enum-value for=PixelFormat>I420</dfn></dt>
   <dd>
-    Planar 4:2:0 YUV.
+    This format is composed of three distinct planes, one plane of Luma and two
+    planes of Chroma, denoted Y, U and V, and present in this order. It is also
+    often refered to as Planar YUV 4:2:0.
+
+    The U an V planes are sub-sampled horizontaly and vertically by a factor of
+    2 compared to the Y planes.
+
+    Each sample in this format is 8 bits.
+
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} samples
+    (and therefore bytes) in the Y plane, arranged starting at the top left in
+    the image, in {{VideoFrame/codedHeight}} lines of {{VideoFrame/codedWidth}}
+    samples.
+
+    There is {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} / 4 samples
+    (and therefore bytes) in the two U and V planes, arranged starting at the
+    top left in the image, in {{VideoFrame/codedHeight}} / 2 lines of
+    {{VideoFrame/codedWidth}} / 2 samples.
+
+    The {{VideoFrame/codedWidth}} and {{VideoFrame/codedHeight}} MUST be even.
+    Similarly, the visible rectangle ({{VideoFrame/displayWidth}} and
+    {{VideoFrame/displayHeight}}) MUST be even.
   </dd>
 </dl>
-
 
 Image Decoding {#image-decoding}
 ====================================

--- a/index.src.html
+++ b/index.src.html
@@ -3335,6 +3335,8 @@ enum PixelFormat {
   "RGBA",
   // 32bpp RGBX (opaque)
   "RGBX",
+  // 32bpp BGRA
+  "BGRA",
 };
 </xmp>
 
@@ -3509,6 +3511,19 @@ enum PixelFormat {
 
     Each sample in this format is 8 bits. The fourth element in each pixel is to
     be ignored, the image is always fully opaque.
+
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} * 4 samples
+    (and therefore bytes) in the single plane, arranged starting at the top left
+    in the image, in {{VideoFrame/codedHeight}} lines of
+    {{VideoFrame/codedWidth}} samples.
+  </dd>
+  <dt><dfn enum-value for=PixelFormat>BGRA</dfn></dt>
+  <dd>
+
+    This format is composed of a single plane, that encodes four components:
+    Blue, Green, Red, and an alpha value, present in this order.
+
+    Each sample in this format is 8 bits.
 
     There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} * 4 samples
     (and therefore bytes) in the single plane, arranged starting at the top left

--- a/index.src.html
+++ b/index.src.html
@@ -3337,6 +3337,8 @@ enum PixelFormat {
   "RGBX",
   // 32bpp BGRA
   "BGRA",
+  // 32bpp BGRX (opaque)
+  "BGRX",
 };
 </xmp>
 
@@ -3524,6 +3526,20 @@ enum PixelFormat {
     Blue, Green, Red, and an alpha value, present in this order.
 
     Each sample in this format is 8 bits.
+
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} * 4 samples
+    (and therefore bytes) in the single plane, arranged starting at the top left
+    in the image, in {{VideoFrame/codedHeight}} lines of
+    {{VideoFrame/codedWidth}} samples.
+  </dd>
+  <dt><dfn enum-value for=PixelFormat>BGRX</dfn></dt>
+  <dd>
+
+    This format is composed of a single plane, that encodes four components:
+    Blue, Green, Red, and a padding value, present in this order.
+
+    Each sample in this format is 8 bits. The fourth element in each pixel is to
+    be ignored, the image is always fully opaque.
 
     There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} * 4 samples
     (and therefore bytes) in the single plane, arranged starting at the top left

--- a/index.src.html
+++ b/index.src.html
@@ -3122,9 +3122,9 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
 
         1. Let |plane| be the Plane identified by |planeIndex| as defined by
             {{VideoFrame/[[format]]}}.
-        2. Let |sampleWidth| be the horizontal pixel size of each subsample
-            for |plane|.
-        3. Let |sampleHeight| be the vertical pixel size of each subsample
+        2. Let |sampleWidth| be the horizontal [=sub-sampling factor=] of each
+            subsample for |plane|.
+        3. Let |sampleHeight| be the vertical [=sub-sampling factor=] of each subsample
             for |plane|.
         4. If |sourceRect|.{{VideoFrameRect/left}} and
             |sourceRect|.{{VideoFrameRect/width}} are not both multiples of
@@ -3149,10 +3149,10 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
         1. Let |plane| be the Plane identified by |planeIndex| as defined by
             {{VideoFrame/[[format]]}}.
         2. Let |sampleBytes| be the number of bytes per sample for |plane|.
-        3. Let |sampleWidth| be the horizontal pixel size of each subsample
-            for |plane|.
-        4. Let |sampleHeight| be the vertical pixel size of each subsample
-            for |plane|.
+        3. Let |sampleWidth| be the horizontal [=sub-sampling factor=] of each
+            subsample for |plane|.
+        4. Let |sampleHeight| be the vertical [=sub-sampling factor=] of each
+            subsample for |plane|.
         5. Let |sampleWidthBytes| be the product of multiplying |sampleWidth| by
             |sampleBytes|.
         6. Let |computedLayout| be a new [=computed plane layout=].
@@ -3342,6 +3342,21 @@ enum PixelFormat {
 };
 </xmp>
 
+<dfn lt="sub-sampling|sub-sampled">Sub-sampling</dfn> is a technique
+where a single sample contains information for multiple pixels in the final
+image. [=Sub-sampling=] can be horizontal, vertical or both, and has a <dfn
+lt="sub-sampling factor|factor">factor</dfn>, that is the number of final pixels
+in the image that are derived from a [=sub-sampled=] sample.
+
+<div class=example>
+  If a {{VideoFrame}} is in {{I420}} format, then the very first
+  component of the second plane (the U plane) corresponds to four pixels, that are
+  the pixels in the top-left angle of the image. Consequently, the first
+  component of the second row corresponds to the four pixels below those initial
+  four top-left pixels. The [=sub-sampling factor=] is 2 in both the horizontal
+  and vertical direction.
+</div>
+
 <dl>
   <dt><dfn enum-value for=PixelFormat>I420</dfn></dt>
   <dd>
@@ -3349,8 +3364,8 @@ enum PixelFormat {
     planes of Chroma, denoted Y, U and V, and present in this order. It is also
     often refered to as Planar YUV 4:2:0.
 
-    The U an V planes are sub-sampled horizontaly and vertically by a factor of
-    2 compared to the Y planes.
+    The U an V planes are [=sub-sampled=] horizontaly and vertically by a
+    [=factor=] of 2 compared to the Y plane.
 
     Each sample in this format is 8 bits.
 
@@ -3376,8 +3391,8 @@ enum PixelFormat {
     present in this order. It is also often refered to as Planar YUV 4:2:0 with
     an alpha channel.
 
-    The U an V planes are sub-sampled horizontaly and vertically by a factor of
-    2 compared to the Y and Alpha planes.
+    The U an V planes are [=sub-sampled=] horizontaly and vertically by a
+    [=factor=] of 2 compared to the Y and Alpha planes.
 
     Each sample in this format is 8 bits.
 
@@ -3402,8 +3417,8 @@ enum PixelFormat {
     planes of Chroma, denoted Y, U and V, and present in this order. It is also
     often refered to as Planar YUV 4:2:2.
 
-    The U an V planes are sub-sampled horizontaly by a factor of 2 compared to
-    the Y planes.
+    The U an V planes are [=sub-sampled=] horizontaly by a [=factor=] of 2
+    compared to the Y plane, and not [=sub-sampled=] vertically.
 
     Each sample in this format is 8 bits.
 
@@ -3443,8 +3458,8 @@ enum PixelFormat {
     another plane for the two Chroma components. The two planes are present in
     this order, and are refered to as respectively the Y plane and the UV plane.
 
-    The U an V components are sub-sampled horizontaly and vertically by a factor
-    of 2 compared to the components in the Y planes.
+    The U an V components are [=sub-sampled=] horizontaly and vertically by a
+    [=factor=] of 2 compared to the components in the Y planes.
 
     Each sample in this format is 8 bits.
 

--- a/index.src.html
+++ b/index.src.html
@@ -3327,6 +3327,8 @@ enum PixelFormat {
   "I420A",
   // 4:2:2 Y, U, V
   "I422",
+  // 4:4:4 Y, U, V
+  "I444",
 };
 </xmp>
 
@@ -3408,6 +3410,21 @@ enum PixelFormat {
     The {{VideoFrame/codedHeight}} MUST be even.  Similarly, the crop
     coordinates ({{VideoFrame/displayWidth}} and {{VideoFrame/displayHeight}})
     MUST be even.
+  </dd>
+  <dt><dfn enum-value for=PixelFormat>I444</dfn></dt>
+  <dd>
+
+    This format is composed of three distinct planes, one plane of Luma and two
+    planes of Chroma, denoted Y, U and V, and present in this order. It is also
+    often refered to as Planar YUV 4:4:4.
+
+    Each sample in this format is 8 bits. This format does not use
+    [=sub-sampling=].
+
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} samples (and
+    therefore bytes) in all three planes, arranged starting at the top left in the
+    image, in {{VideoFrame/codedHeight}} lines of {{VideoFrame/codedWidth}}
+    samples.
   </dd>
 </dl>
 


### PR DESCRIPTION
Please have a look. Which other formats do we need to support initially (= what formats does Chrome plan to ship with) ? I know there was mentions of NV12.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/288.html" title="Last updated on Jul 15, 2021, 2:07 PM UTC (81759cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/288/3584fb9...81759cc.html" title="Last updated on Jul 15, 2021, 2:07 PM UTC (81759cc)">Diff</a>