### PR TITLE
Update AudioSampleFormat

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2507,8 +2507,8 @@ An audio sample format describes the numeric type used to represent a
 single sample (e.g. 32-bit floating point) and the arrangement of samples from
 different channels as either [=interleaved=] or [=planar=]. The <dfn>audio
 sample type</dfn> refers solely to the numeric type and interval used to store
-the data, this is {{U8}}, {{S16}}, {{S24}}, {{S32}}, or {{FLT}} for respectively
-unsigned 8-bits, signed 16-bits, signed 32-bits, signed 32-bits, and 32-bits
+the data, this is {{u8}}, {{s16}}, {{s32}}, or {{f32}} for respectively
+unsigned 8-bits, signed 16-bits, signed 32-bits, and 32-bits
 floating point number. The [[#audio-buffer-arrangement|audio buffer
 arrangement]] refers solely to the way the samples are laid out in memory
 ([=planar=] or [=interleaved=]).
@@ -2530,49 +2530,40 @@ also uses Linear PCM.
 
 <xmp class='idl'>
 enum AudioSampleFormat {
-  "U8",
-  "S16",
-  "S24",
-  "S32",
-  "FLT",
-  "U8P",
-  "S16P",
-  "S24P",
-  "S32P",
-  "FLTP",
+  "u8",
+  "s16",
+  "s32",
+  "f32",
+  "u8-planar",
+  "s16-planar",
+  "s32-planar",
+  "f32-planar",
 };
 </xmp>
 
-: <dfn enum-value for=AudioSampleFormat>U8</dfn>
+: <dfn enum-value for=AudioSampleFormat>u8</dfn>
 :: [[WEBIDL#idl-octet|8-bit unsigned integer]] [=samples=] with [=interleaved=] [[#audio-buffer-arrangement|channel arrangement]].
 
-: <dfn enum-value for=AudioSampleFormat>S16</dfn>
+: <dfn enum-value for=AudioSampleFormat>s16</dfn>
 :: [[WEBIDL#idl-short|16-bit signed integer]] [=samples=] with [=interleaved=] [[#audio-buffer-arrangement|channel arrangement]].
 
-: <dfn enum-value for=AudioSampleFormat>S24</dfn>
-:: [[WEBIDL#idl-long|32-bit signed integer]] [=samples=] with [=interleaved=] [[#audio-buffer-arrangement|channel arrangement]], holding value in the 24-bit of lowest significance.
-
-: <dfn enum-value for=AudioSampleFormat>S32</dfn>
+: <dfn enum-value for=AudioSampleFormat>s32</dfn>
 :: [[WEBIDL#idl-long|32-bit signed integer]] [=samples=] with [=interleaved=] [[#audio-buffer-arrangement|channel arrangement]].
 
-: <dfn enum-value for=AudioSampleFormat>FLT</dfn>
+: <dfn enum-value for=AudioSampleFormat>f32</dfn>
 :: [[WEBIDL#idl-float|32-bit float]] [=samples=] with [=interleaved=] [[#audio-buffer-arrangement|channel arrangement]].
 
-: <dfn enum-value for=AudioSampleFormat>U8P</dfn>
+: <dfn enum-value for=AudioSampleFormat>u8-planar</dfn>
 :: [[WEBIDL#idl-octet|8-bit unsigned integer]] [=samples=] with [=planar=] [[#audio-buffer-arrangement|channel arrangement]].
 
-: <dfn enum-value for=AudioSampleFormat>S16P</dfn>
+: <dfn enum-value for=AudioSampleFormat>s16-planar</dfn>
 :: [[WEBIDL#idl-short|16-bit signed integer]] [=samples=] with [=planar=] [[#audio-buffer-arrangement|channel arrangement]].
 
-: <dfn enum-value for=AudioSampleFormat>S24P</dfn>
-:: [[WEBIDL#idl-long|32-bit signed integer]] [=samples=] with [=planar=] [[#audio-buffer-arrangement|channel arrangement]], holding value in the 24-bit of lowest significance.
-
-: <dfn enum-value for=AudioSampleFormat>S32P</dfn>
+: <dfn enum-value for=AudioSampleFormat>s32-planar</dfn>
 :: [[WEBIDL#idl-long|32-bit signed integer]] [=samples=] with [=planar=] [[#audio-buffer-arrangement|channel arrangement]].
 
-: <dfn enum-value for=AudioSampleFormat>FLTP</dfn>
+: <dfn enum-value for=AudioSampleFormat>f32-planar</dfn>
 :: [[WEBIDL#idl-float|32-bit float]] [=samples=] with [=planar=] [[#audio-buffer-arrangement|channel arrangement]].
-
 
 ### Arrangement of audio buffer ### {#audio-buffer-arrangement}
 
@@ -2590,7 +2581,7 @@ in different buffers, themselves arranged in an order described in the section
 {{AudioData}}'s {{AudioData/[[number of channels]]}}. Each plane contains
 {{AudioData/[[number of frames]]}} elements.
 
-Note: The [[WEBAUDIO|Web Audio API]] currently uses {{FLTP}} exclusively.
+Note: The [[WEBAUDIO|Web Audio API]] currently uses {{f32-planar}} exclusively.
 
 <div class='note'>
 Note: The following diagram exemplifies the memory layout of [=planar=] versus
@@ -2624,35 +2615,28 @@ An audio buffer comprised only of values equal to the [=bias value=] is silent.
 </thead>
 <tbody>
 <tr class="odd">
-<td>{{U8}}</td>
+<td>{{u8}}</td>
 <td>[[WEBIDL#idl-octet|octet]]</td>
 <td>0</td>
 <td>128</td>
 <td>+255</td>
 </tr>
 <tr class="even">
-<td>{{S16}}</td>
+<td>{{s16}}</td>
 <td>[[WEBIDL#idl-short|short]]</td>
 <td>-32768</td>
 <td>0</td>
 <td>+32767</td>
 </tr>
 <tr class="odd">
-<td>{{S24}}</td>
-<td>[[WEBIDL#idl-long|long]]</td>
-<td>-8388608</td>
-<td>0</td>
-<td>+8388607</td>
-</tr>
-<tr class="even">
-<td>{{S32}}</td>
+<td>{{s32}}</td>
 <td>[[WEBIDL#idl-long|long]]</td>
 <td>-2147483648</td>
 <td>0</td>
 <td>+2147483647</td>
 </tr>
-<tr class="odd">
-<td>{{FLT}}</td>
+<tr class="even">
+<td>{{f32}}</td>
 <td>[[WEBIDL#idl-float|float]]</td>
 <td>-1.0</td>
 <td>0.0</td>
@@ -2663,7 +2647,8 @@ An audio buffer comprised only of values equal to the [=bias value=] is silent.
 
 Note: There is no data type that can hold 24 bits of information conveniently,
 but audio content using 24-bit samples is common, so 32-bits integers are
-commonly used to hold 24-bit content.
+commonly used to hold 24-bit content. It is recommended to left-shift 24-bit
+content by `8`, to convert the data to {{s32}} or {{s32-planar}}.
 
 ### Audio channel ordering ### {#audio-channel-ordering}
 

--- a/index.src.html
+++ b/index.src.html
@@ -2519,13 +2519,13 @@ signal at a particular point in time in a particular channel.
 A <dfn>frame</dfn> or (sample-frame) refers to a set of values of all channels
 of a multi-channel signal, that happen at the exact same time.
 
-Note: Consequently if an audio signal is mono (has only one channel), a frame
+NOTE: Consequently if an audio signal is mono (has only one channel), a frame
 and a sample refer to the same thing.
 
 All audio [=samples=] in this specification are using linear pulse-code
 modulation (Linear PCM): quantization levels are uniform between values.
 
-Note: The Web Audio API, that is expected to be used with this specification,
+NOTE: The Web Audio API, that is expected to be used with this specification,
 also uses Linear PCM.
 
 <xmp class='idl'>
@@ -2581,10 +2581,10 @@ in different buffers, themselves arranged in an order described in the section
 {{AudioData}}'s {{AudioData/[[number of channels]]}}. Each plane contains
 {{AudioData/[[number of frames]]}} elements.
 
-Note: The [[WEBAUDIO|Web Audio API]] currently uses {{f32-planar}} exclusively.
+NOTE: The [[WEBAUDIO|Web Audio API]] currently uses {{f32-planar}} exclusively.
 
 <div class='note'>
-Note: The following diagram exemplifies the memory layout of [=planar=] versus
+NOTE: The following diagram exemplifies the memory layout of [=planar=] versus
     [=interleaved=] {{AudioSampleFormat}}s
 
 <img alt="Graphical representation the memory layout of interleaved and planar
@@ -2645,13 +2645,19 @@ An audio buffer comprised only of values equal to the [=bias value=] is silent.
 </tbody>
 </table>
 
-Note: There is no data type that can hold 24 bits of information conveniently,
+NOTE: There is no data type that can hold 24 bits of information conveniently,
 but audio content using 24-bit samples is common, so 32-bits integers are
 commonly used to hold 24-bit content.
 
-{{AudioDecoder}}s decoding 24-bit audio chunks MUST convert their output to
-{{s32}} or {{s32-planar}}, by left-shifting the decoded samples by `8` before
-exposing them as {{AudioData}}.
+{{AudioData}} containing 24-bit samples SHOULD store those samples in {{s32}} or
+{{f32}}. When samples are stored in {{s32}}, each sample MUST be left-shifted by
+`8` bits. By virtue of this process, samples outside of the valid 24-bit range
+([-8388608, +8388608]) will be clipped. To avoid clipping and ensure lossless
+transport, samples may be converted to {{f32}}.
+
+NOTE: While clipping is unavoidable in {{u8}}, {{s16}}, and {{s32}} samples due
+to their storage types, implementations SHOULD take care not to clip internally
+when handling {{f32}} samples.
 
 ### Audio channel ordering ### {#audio-channel-ordering}
 
@@ -2664,7 +2670,7 @@ When encoding, the ordering of the audio channels in the resulting
 
 In other terms, no channel reordering is performed when encoding and decoding.
 
-Note: The container either implies or specifies the channel mapping: the
+NOTE: The container either implies or specifies the channel mapping: the
 channel attributed to a particular channel index.
 
 

--- a/index.src.html
+++ b/index.src.html
@@ -2652,7 +2652,7 @@ commonly used to hold 24-bit content.
 {{AudioData}} containing 24-bit samples SHOULD store those samples in {{s32}} or
 {{f32}}. When samples are stored in {{s32}}, each sample MUST be left-shifted by
 `8` bits. By virtue of this process, samples outside of the valid 24-bit range
-([-8388608, +8388608]) will be clipped. To avoid clipping and ensure lossless
+([-8388608, +8388607]) will be clipped. To avoid clipping and ensure lossless
 transport, samples may be converted to {{f32}}.
 
 NOTE: While clipping is unavoidable in {{u8}}, {{s16}}, and {{s32}} samples due

--- a/index.src.html
+++ b/index.src.html
@@ -2419,7 +2419,7 @@ dictionary AudioDataInit {
     5. Assign `0` to |data|'s {{AudioData/[[number of channels]]}}.
     6. Assign `""` to |data|'s {{AudioData/[[format]]}}.
 
-: To check if a {{AudioDataInit}} is a 
+: To check if a {{AudioDataInit}} is a
     <dfn>valid AudioDataInit</dfn>, run these steps:
 :: 1. If {{AudioDataInit/sampleRate}} less than or equal to `0`, return `false`.
     2. If {{AudioDataInit/numberOfFrames}} = `0`, return `false`.
@@ -2647,8 +2647,11 @@ An audio buffer comprised only of values equal to the [=bias value=] is silent.
 
 Note: There is no data type that can hold 24 bits of information conveniently,
 but audio content using 24-bit samples is common, so 32-bits integers are
-commonly used to hold 24-bit content. It is recommended to left-shift 24-bit
-content by `8`, to convert the data to {{s32}} or {{s32-planar}}.
+commonly used to hold 24-bit content.
+
+{{AudioDecoder}}s decoding 24-bit audio chunks MUST convert their output to
+{{s32}} or {{s32-planar}}, by left-shifting the decoded samples by `8` before
+exposing them as {{AudioData}}.
 
 ### Audio channel ordering ### {#audio-channel-ordering}
 


### PR DESCRIPTION
Fixes #300

- Uses lowercase for all AudioSampleFormat enums
- Uses `"-planar"` instead of `"p"`
- Removes `"s24"` and `"s24-planar"` formats.
- Adds a note recommending left-shift by 8 for converting from 24-bit to `"s32"`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tguilbert-google/webcodecs/pull/307.html" title="Last updated on Jul 28, 2021, 12:27 AM UTC (011f41a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/307/2cbb1e2...tguilbert-google:011f41a.html" title="Last updated on Jul 28, 2021, 12:27 AM UTC (011f41a)">Diff</a>