### PR TITLE
Fix copy/paste error in the AudioDecoder.decode definition

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -361,7 +361,7 @@ Methods {#audiodecoder-methods}
         {{EncodingError}}.
     3. Queue a task on the [=control thread=] event loop to decrement
         {{AudioDecoder/[[decodeQueueSize]]}}.
-    4. Let |decoded outputs| be a [=list=] of decoded video data outputs emitted
+    4. Let |decoded outputs| be a [=list=] of decoded audio data outputs emitted
         by {{AudioDecoder/[[codec implementation]]}}.
     5. If |decoded outputs| is not empty, queue a task on the [=control thread=]
         event loop to run the [=Output AudioData=] algorithm with


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/312.html" title="Last updated on Jul 28, 2021, 3:43 PM UTC (9c89379)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/312/88e74a4...9c89379.html" title="Last updated on Jul 28, 2021, 3:43 PM UTC (9c89379)">Diff</a>