### PR TITLE
Add Vorbis to the registry

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -38,6 +38,11 @@ jobs:
             echidna_token: ECHIDNA_TOKEN_AVC_REGISTRATION
             build_override: |
               status: NOTE-WD
+          - source: vorbis_codec_registration.src.html
+            destination: vorbis_codec_registration.html
+            echidna_token: ECHIDNA_TOKEN_VORBIS_REGISTRATION
+            build_override: |
+              status: NOTE-WD
     steps:
       # See doc at https://github.com/actions/checkout#checkout-v2
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 avc_codec_registration.html
 codec_registry.html
+vorbis_codec_registration.html
 /index.html
 out/
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 
-local: local-index local-codec-registry local-avc-codec-registration
+local: local-index local-codec-registry local-avc-codec-registration vorbis_codec_registration
 
 local-index: index.src.html
 	bikeshed --die-on=warning spec index.src.html index.html
@@ -10,6 +10,9 @@ local-codec-registry: codec_registry.src.html
 
 local-avc-codec-registration: avc_codec_registration.src.html
 	bikeshed --die-on=warning spec avc_codec_registration.src.html avc_codec_registration.html
+
+local-vorbis-codec-registration: vorbis_codec_registration.src.html
+	bikeshed --die-on=warning spec vorbis_codec_registration.src.html vorbis_codec_registration.html
 
 remote-index: index.src.html
 	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
@@ -50,12 +53,26 @@ remote-avc-codec-registration: avc_codec_registration.src.html
 		exit 22 \
 	);
 
+remote-vorbis-codec-registration: vorbis_codec_registration.src.html
+	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	                       --output vorbis_codec_registration.html \
+	                       --write-out "%{http_code}" \
+	                       --header "Accept: text/plain, text/html" \
+	                       -F die-on=warning \
+	                       -F file=@vorbis_codec_registration.src.html) && \
+	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
+		echo ""; cat vorbis_codec_registration.html; echo ""; \
+		rm -f vorbis_codec_registration.html; \
+		exit 22 \
+	);
 
-remote: remote-index remote-codec-registry remote-avc-codec-registration
 
-ci: index.src.html codec_registry.src.html avc_codec_registration.src.html
+remote: remote-index remote-codec-registry remote-avc-codec-registration remote-vorbis_codec_registration
+
+ci: index.src.html codec_registry.src.html avc_codec_registration.src.html vorbis_codec_registration.src.html
 	mkdir -p out
 	make remote
 	mv index.html out/index.html
 	mv codec_registry.html out/codec_registry.html
 	mv avc_codec_registration.html out/avc_codec_registration.html
+	mv vorbis_codec_registration.html out/vorbis_codec_registration.html

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -11,8 +11,6 @@ Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
-Boilerplate: omit conformance
-
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for AVC (H.264), the (1) fully qualified codec strings, (2)
     the {{VideoDecoderConfig.description}} bytes, (3) the codec-specific

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -113,7 +113,7 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
   <tr>
     <td>vorbis</td>
     <td>Vorbis</td>
-    <td>TODO (AudoDecoderConfig.description)</td>
+    <td>[Vorbis I specification](https://xiph.org/vorbis/doc/Vorbis_I_spec.html) [[WEBCODECS-VORBIS-CODEC-REGISTRATION]]</td>
   </tr>
   <tr>
     <td>ulaw</td>
@@ -158,11 +158,6 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
     <td>vp09.*</td>
     <td>VP9</td>
     <td>TODO (string)</td>
-  </tr>
-  <tr>
-    <td>vorbis</td>
-    <td>Vorbis</td>
-    <td>[Vorbis I specification](https://xiph.org/vorbis/doc/Vorbis_I_spec.html) [[WEBCODECS-VORBIS-CODEC-REGISTRATION]]</td>
   </tr>
 </table>
 

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -159,6 +159,11 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
     <td>VP9</td>
     <td>TODO (string)</td>
   </tr>
+  <tr>
+    <td>vorbis</td>
+    <td>Vorbis</td>
+    <td>[Vorbis I specification](https://xiph.org/vorbis/doc/Vorbis_I_spec.html) [[WEBCODECS-VORBIS-CODEC-REGISTRATION]]</td>
+  </tr>
 </table>
 
 Privacy and Security Considerations {#privacy-and-security-considerations}

--- a/vorbis_codec_registration.src.html
+++ b/vorbis_codec_registration.src.html
@@ -15,7 +15,7 @@ Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for Vorbis, the (1) fully qualified codec strings, (2)
     the {{AudioDecoderConfig.description}} bytes, (3) the codec-specific
     {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] bytes, and (4)
-    the meaning of {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+    the values of {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -34,11 +34,11 @@ Markup Shorthands:css no, markdown yes, dfn yes
 <pre class='anchors'>
 spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: attribute
-        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
         text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
         text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
         text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
     type: dfn
+        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
         for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
         for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
     type: interface
@@ -92,11 +92,11 @@ NOTE: The comments header content is not used by [[WEBCODECS]].
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================
 
-The [=EncodedAudioChunk/[[type]]=] is not used in this codec, its value is
-ignored.
+The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
+Vorbis is always "[=EncodedAudioChunkType/key=]".
 
 NOTE: Once the initialization has succeeded, any Vorbis packet can be decoded at
-any time, not necessarily in sequence, there is no concept of key-frames.
+any time without error, but this might not result in the expected audio output.
 
 Privacy and Security Considerations {#privacy-and-security-considerations}
 ==========================================================================

--- a/vorbis_codec_registration.src.html
+++ b/vorbis_codec_registration.src.html
@@ -1,0 +1,98 @@
+<pre class='metadata'>
+Title: Vorbis WebCodecs Registration
+Repository: w3c/webcodecs
+Status: NOTE-ED
+Shortname: webcodecs-vorbis-codec-registration
+Level: none
+Group: mediawg
+ED: https://w3c.github.io/webcodecs/vorbis_codec_registration.html
+TR: https://www.w3.org/TR/webcodecs-vorbis-codec-registration/
+Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
+Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
+Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+
+Abstract: This registration is entered into the [[webcodecs-codec-registry]].
+    It describes, for Vorbis, the (1) fully qualified codec strings, (2)
+    the {{AudioDecoderConfig.description}} bytes, (3) the codec-specific
+    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] bytes, and (4)
+    the meaning of {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+
+    The registration is not intended to include any information on whether a
+    codec format is encumbered by intellectual property claims. Implementers and
+    authors are advised to seek appropriate legal counsel in this matter if they
+    intend to implement or use a specific codec format. Implementers of
+    WebCodecs are not required to support the Vorbis codec.
+
+    This registration is non-normative.
+
+Markup Shorthands:css no, markdown yes, dfn yes
+!Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
+!Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
+</pre>
+
+<pre class='anchors'>
+spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
+    type: attribute
+        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
+        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
+        text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
+        text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
+    type: dfn
+        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
+        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
+    type: interface
+        text: EncodedAudioChunk; url: encodedaudiochunk
+    type: dictionary
+        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
+</pre>
+
+<pre class='biblio'>
+{
+  "VORBIS": {
+    "href": "https://xiph.org/vorbis/doc/Vorbis_I_spec.html",
+    "title": "Vorbis I specification",
+    "publisher": "Xiph.Org Foundation",
+    "date": "July 4, 2020"
+  }
+}
+</pre>
+
+Fully qualified codec strings {#fully-qualified-codec-strings}
+==============================================================
+
+The codec string is `"vorbis"`.
+
+EncodedAudioChunk data {#encodedaudiochunk-data}
+================================================
+
+{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
+an "audio packet", as described in the section 4.3 of the [[VORBIS]] specification.
+
+AudioDecoderConfig description {#audiodecoderconfig-description}
+================================================================
+
+{{AudioDecoderConfig.description}} is required. It is assumed to be three
+Vorbis header packets, respectively the identification header, the comments
+header, and the setup header, in this order, as described in section 4.2 of [[VORBIS]].
+
+The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.channelCount}}
+members are overridden by what the decoder finds in the identification header.
+
+NOTE: The comments header content is not used by [[WEBCODECS]].
+
+EncodedAudioChunk type {#encodedaudiochunk-type}
+================================================
+
+The [=EncodedAudioChunk/[[type]]=] is not used in this codec, its value is
+ignored.
+
+NOTE: Once the initialization has succeeded, any Vorbis packet can be decoded at
+any time, not necessarily in sequence, there is no concept of key-frames.
+
+Privacy and Security Considerations {#privacy-and-security-considerations}
+==========================================================================
+
+Please refer to the [[WEBCODECS#privacy-considerations|Privacy Considerations]]
+and [[WEBCODECS#security-considerations|Security Considerations]] sections in
+[[WEBCODECS]].

--- a/vorbis_codec_registration.src.html
+++ b/vorbis_codec_registration.src.html
@@ -54,6 +54,11 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     "title": "Vorbis I specification",
     "publisher": "Xiph.Org Foundation",
     "date": "July 4, 2020"
+  },
+  "OGG-FRAMING": {
+    "href": "https://xiph.org/vorbis/doc/framing.html",
+    "title": "Ogg logical bitstream framing",
+    "publisher": "Xiph.Org Foundation"
   }
 }
 </pre>
@@ -72,9 +77,12 @@ an "audio packet", as described in the section 4.3 of the [[VORBIS]] specificati
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-{{AudioDecoderConfig.description}} is required. It is assumed to be three
-Vorbis header packets, respectively the identification header, the comments
-header, and the setup header, in this order, as described in section 4.2 of [[VORBIS]].
+{{AudioDecoderConfig.description}} is required. It is assumed to be in Xiph
+extradata format, described in [[OGG-FRAMING]]. This format consists in the
+`page_segments` field, followed by the `segment_table` field, followed by the
+three Vorbis header packets, respectively the identification header, the comments
+header, and the setup header, in this order, as described in section 4.2 of
+[[VORBIS]].
 
 The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.channelCount}}
 members are overridden by what the decoder finds in the identification header.


### PR DESCRIPTION
Does what it says. I have an open question:

Are the three header packet required, or just the last one? The first one allows getting the channel number/sample-rate, what if it contradicts what has been passed in? Do we consider it kind of part of the container and expect authors to bit-shift their way to this piece of info to set up the decoder (which would work, but then it's clearly in the codec bytestream, so that's unclear), or do we state (like is in the proposed text here) that the values in the `AudioDecoderConfig` are not required, or ignored ? The second header is useless for Web Codecs in any case.