### PR TITLE
Add best practices section for using WebCodecs.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4704,15 +4704,14 @@ may implement a "privacy budget", which depletes as authors use WebCodecs and
 other identifying APIs. Upon exhaustion of the privacy budget, codec
 capabilities could be reduced to a common baseline or prompt for user approval.
 
-Best Practies for Authors Using WebCodecs{#best-practices-developers}
-=====================================================================
+Best Practices for Authors Using WebCodecs{#best-practices-developers}
+======================================================================
 
 While WebCodecs internally operates on background threads, authors working with
 realtime media or in contended main thread environments should ensure their
 media pipelines operate in worker contexts entirely independent of the main
-thread where possible. For example, any processing of {{VideoFrame}}s for
-encoders or from decoders working with realtime media should generally be done
-in a worker context.
+thread where possible. For example, realtime media processing of {{VideoFrame}}s
+should generally be done in a worker context.
 
 The main thread has significant potential for high contention and jank that may
 go unnoticed in development, yet degrade inconsistently across devices and User

--- a/index.src.html
+++ b/index.src.html
@@ -4663,6 +4663,7 @@ immutable.
 
 Privacy Considerations{#privacy-considerations}
 ===============================================
+
 The primary privacy impact is an increased ability to fingerprint users by
 querying for different codec capabilities to establish a codec feature profile.
 Much of this profile is already exposed by existing APIs. Such profiles are very
@@ -4702,3 +4703,23 @@ attempts to exhaustively probe for codec capabilities. Additionally, User Agents
 may implement a "privacy budget", which depletes as authors use WebCodecs and
 other identifying APIs. Upon exhaustion of the privacy budget, codec
 capabilities could be reduced to a common baseline or prompt for user approval.
+
+Best Practies for Authors Using WebCodecs{#best-practices-developers}
+=====================================================================
+
+While WebCodecs internally operates on background threads, authors working with
+realtime media or in contended main thread environments should ensure their
+media pipelines operate in worker contexts entirely independent of the main
+thread where possible. For example, any processing of {{VideoFrame}}s for
+encoders or from decoders working with realtime media should generally be done
+in a worker context.
+
+The main thread has significant potential for high contention and jank that may
+go unnoticed in development, yet degrade inconsistently across devices and User
+Agents in the field -- potentially dramatically impacting the end user
+experience. Ensuring the media pipeline is decoupled from the main thread helps
+provide a smooth experience for end users.
+
+Authors using the main thread for their media pipeline should be sure of their
+target frame rates, main thread work load, how their application will be
+embedded, and the class of devices their users will be using.


### PR DESCRIPTION
Per the resolution of the chairs, WebCodecs will be exposed in
windows and worker contexts. As part of that resolution the
chairs asked that we include a best practices section.

This section recommends authors move their media pipelines to
worker contexts where possible and highlights areas of concern
for those who still choose to operate in a worker.

Fixes: #211


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/316.html" title="Last updated on Jul 30, 2021, 12:41 AM UTC (44740f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/316/03e42e7...44740f6.html" title="Last updated on Jul 30, 2021, 12:41 AM UTC (44740f6)">Diff</a>