### PR TITLE
Add Opus to the registry

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -53,6 +53,11 @@ jobs:
             echidna_token: ECHIDNA_TOKEN_FLAC_REGISTRATION
             build_override: |
               status: NOTE-WD
+          - source: opus_codec_registration.src.html
+            destination: opus_codec_registration.html
+            echidna_token: ECHIDNA_TOKEN_OPUS_REGISTRATION
+            build_override: |
+              status: NOTE-WD
     steps:
       # See doc at https://github.com/actions/checkout#checkout-v2
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ avc_codec_registration.html
 codec_registry.html
 vorbis_codec_registration.html
 mp3_codec_registration.html
-flac_codec_registration.src.html
+flac_codec_registration.html
+opus_codec_registration.html
 /index.html
 out/
 

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -110,7 +110,9 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
   <tr>
     <td>opus</td>
     <td>Opus</td>
-    <td>TODO (AudioDecoderConfig.description)</td>
+    <td>[Opus WebCodecs
+      Registration](https://www.w3.org/TR/webcodecs-opus-codec-registration/)
+    [[WEBCODECS-OPUS-CODEC-REGISTRATION]]</td>
   </tr>
   <tr>
     <td>vorbis</td>

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -76,6 +76,13 @@ An {{EncodedAudioChunk}} containing Opus can be in two different formats,
 depending on if {{AudioDecoderConfig.description}} has been set during
 initialization.
 
+
+AudioDecoderConfig description {#audiodecoderconfig-description}
+================================================================
+
+{{AudioDecoderConfig.description}} can optionally set to an Identification
+Header, described in section 5.1 of [[OPUS-IN-OGG]].
+
 If an {{AudioDecoderConfig.description}} has been set, the
 {{EncodedAudioChunk}}s passed to the {{AudioDecoder.decode}}} method have to be
 in audio data packets, as described in [section
@@ -85,13 +92,6 @@ If an {{AudioDecoderConfig.description}} has not been set, then the
 {{EncodedAudioChunk}}s passed to the {{AudioDecoder.decode}} method have to be
 Opus packets, as described in [section
 3](https://datatracker.ietf.org/doc/html/rfc6716#section-3) of [[OPUS]].
-
-
-AudioDecoderConfig description {#audiodecoderconfig-description}
-================================================================
-
-{{AudioDecoderConfig.description}} can optionally set to an Identification
-Header, described in section 5.1 of [[OPUS-IN-OGG]].
 
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -1,0 +1,92 @@
+<pre class='metadata'>
+Title: Opus WebCodecs Registration
+Repository: w3c/webcodecs
+Status: NOTE-ED
+Shortname: webcodecs-opus-codec-registration
+Level: none
+Group: mediawg
+ED: https://w3c.github.io/webcodecs/opus_codec_registration.html
+TR: https://www.w3.org/TR/webcodecs-opus-codec-registration/
+Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
+Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
+Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+
+Abstract: This registration is entered into the [[webcodecs-codec-registry]].
+    It describes, for Opus, the (1) fully qualified codec strings, (2)
+    the {{AudioDecoderConfig.description}} bytes, (3) the codec-specific
+    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] bytes, and (4)
+    the values of {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+
+    The registration is not intended to include any information on whether a
+    codec format is encumbered by intellectual property claims. Implementers and
+    authors are advised to seek appropriate legal counsel in this matter if they
+    intend to implement or use a specific codec format. Implementers of
+    WebCodecs are not required to support the Opus codec.
+
+    This registration is non-normative.
+
+Markup Shorthands:css no, markdown yes, dfn yes
+!Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
+!Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
+</pre>
+
+<pre class='anchors'>
+spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
+    type: attribute
+        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
+    type: dfn
+        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
+        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
+        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
+    type: interface
+        text: EncodedAudioChunk; url: encodedaudiochunk
+    type: dictionary
+        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
+</pre>
+
+<pre class='biblio'>
+{
+  "OPUS": {
+    "href": "https://datatracker.ietf.org/doc/html/rfc6716",
+    "title": "RFC 6716: Definition of the Opus Audio Codec",
+    "publisher": "IETF",
+    "date": "September 2012"
+  }
+}
+</pre>
+
+Fully qualified codec strings {#fully-qualified-codec-strings}
+==============================================================
+
+The codec string is `"opus"`.
+
+EncodedAudioChunk data {#encodedaudiochunk-data}
+================================================
+
+{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
+a "packet", as described in the section 3 of the [[OPUS]] specification.
+
+NOTE: The self-delimiting framing described in Appendix B of [[OPUS]] is not
+supported.
+
+AudioDecoderConfig description {#audiodecoderconfig-description}
+================================================================
+
+{{AudioDecoderConfig.description}} is not used when decoding Opus.
+
+EncodedAudioChunk type {#encodedaudiochunk-type}
+================================================
+
+The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
+Opus is always "[=EncodedAudioChunkType/key=]".
+
+NOTE: Once the initialization has succeeded, any Opus packet can be decoded at
+any time without error, but this might not result in the expected audio output.
+
+Privacy and Security Considerations {#privacy-and-security-considerations}
+==========================================================================
+
+Please refer to the [[WEBCODECS#privacy-considerations|Privacy Considerations]]
+and [[WEBCODECS#security-considerations|Security Considerations]] sections in
+[[WEBCODECS]].

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -39,6 +39,8 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
         for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
         for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
         for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
+    type: method
+        for: AudioDecoder; text: AudioDecoder.decode; url: dom-audiodecoder-decode
     type: interface
         text: EncodedAudioChunk; url: encodedaudiochunk
     type: dictionary
@@ -52,6 +54,12 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     "title": "RFC 6716: Definition of the Opus Audio Codec",
     "publisher": "IETF",
     "date": "September 2012"
+  },
+  "OPUS-IN-OGG": {
+    "href": "https://datatracker.ietf.org/doc/html/rfc7845",
+    "title": "RFC 7845: Ogg Encapsulation for the Opus Audio Codec",
+    "publisher": "IETF",
+    "date": "April 2016"
   }
 }
 </pre>
@@ -64,16 +72,26 @@ The codec string is `"opus"`.
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================
 
-{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
-a "packet", as described in the section 3 of the [[OPUS]] specification.
+An {{EncodedAudioChunk}} containing Opus can be in two different formats,
+depending on if {{AudioDecoderConfig.description}} has been set during
+initialization.
 
-NOTE: The self-delimiting framing described in Appendix B of [[OPUS]] is not
-supported.
+If an {{AudioDecoderConfig.description}} has been set, the
+{{EncodedAudioChunk}}s passed to the {{AudioDecoder.decode}}} method have to be
+in audio data packets, as described in [section
+2](https://datatracker.ietf.org/doc/html/rfc7845#section-3) of [[OPUS-IN-OGG]].
+
+If an {{AudioDecoderConfig.description}} has not been set, then the
+{{EncodedAudioChunk}}s passed to the {{AudioDecoder.decode}} method have to be
+Opus packets, as described in [section
+3](https://datatracker.ietf.org/doc/html/rfc6716#section-3) of [[OPUS]].
+
 
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-{{AudioDecoderConfig.description}} is not used when decoding Opus.
+{{AudioDecoderConfig.description}} can optionally set to an Identification
+Header, described in section 5.1 of [[OPUS-IN-OGG]].
 
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================
@@ -81,8 +99,8 @@ EncodedAudioChunk type {#encodedaudiochunk-type}
 The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
 Opus is always "[=EncodedAudioChunkType/key=]".
 
-NOTE: Once the initialization has succeeded, any Opus packet can be decoded at
-any time without error, but this might not result in the expected audio output.
+NOTE: Once the initialization has succeeded, any packet can be decoded at any
+time without error, but this might not result in the expected audio output.
 
 Privacy and Security Considerations {#privacy-and-security-considerations}
 ==========================================================================


### PR DESCRIPTION
This has the `Makefile` changes so it builds, but I'll rebase that.

In contrast to Vorbis, the rate and channel count are required ahead of time here. The rate must be in [8, 12, 16, 24, 48] kHz, and the channel count is either 1 or 2, this is a user request, the decoder outputs what is requested as long as it's a valid Opus bytestream.