### PR TITLE
Add presentation order text to standard

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -613,6 +613,11 @@ Methods {#videodecoder-methods}
         failing to release them (or waiting for garbage collection) may cause
         decoding to stall.
 
+    NOTE: {{VideoDecoder}} requires that frames are output in the order they
+        expect to be presented, commonly known as presentation order. Some
+        {{VideoDecoder/[[codec implementation]]}}s may require the User Agent
+        to reorder outputs into presentation order.
+
     When invoked, run these steps:
     1. If {{VideoDecoder/[[state]]}} is not `"configured"`, throw an
         {{InvalidStateError}}.
@@ -637,7 +642,7 @@ Methods {#videodecoder-methods}
     3. Queue a task on the [=control thread=] event loop to decrement
         {{VideoDecoder/[[decodeQueueSize]]}}
     4. Let |decoded outputs| be a [=list=] of decoded video data outputs emitted
-        by {{VideoDecoder/[[codec implementation]]}}.
+        by {{VideoDecoder/[[codec implementation]]}} in presentation order.
     5. If |decoded outputs| is not empty, queue a task on the [=control thread=]
         event loop to run the [=Output VideoFrames=] algorithm with
         |decoded outputs|.


### PR DESCRIPTION
Fixes: #55


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/320.html" title="Last updated on Aug 3, 2021, 10:47 PM UTC (d0b5043)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/320/03e42e7...d0b5043.html" title="Last updated on Aug 3, 2021, 10:47 PM UTC (d0b5043)">Diff</a>