### PR TITLE
Clarify codec string requirements around profile, level, constraint.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1445,17 +1445,17 @@ Run these steps:
 1. If |config| is an {{AudioDecoderConfig}} or {{VideoDecoderConfig}} and the
     User Agent can't provide a <a>codec</a> that can decode the exact profile
     (where present), level (where present), and constraint bits (where present)
-    indicated by the {{Codec String}}, return `false`.
+    indicated by the <a>Codec String</a>, return `false`.
 2. If |config| is an {{AudioEncoderConfig}} or {{VideoEncoderConfig}}:
-    1. If the {{Codec String}} contains a profile and the User Agent can't
+    1. If the <a>Codec String</a> contains a profile and the User Agent can't
         provide a <a>codec</a> that can encode the exact profile indicated by
-        the {{Codec String}}, return `false`.
-    2. If the {{Codec String}} contains a level and the User Agent can't
+        the <a>Codec String</a>, return `false`.
+    2. If the <a>Codec String</a> contains a level and the User Agent can't
         provide a <a>codec</a> that can encode to a level less than or equal to
-        the level indicated by the {{Codec String}}, return `false`.
-    3. If the {{Codec String}} contains constraint bits and the User Agent
+        the level indicated by the <a>Codec String</a>, return `false`.
+    3. If the <a>Codec String</a> contains constraint bits and the User Agent
         can't provide a <a>codec</a> that can produce an encoded bitstream at
-        least as constrained as indicated by the {{Codec String}}, return
+        least as constrained as indicated by the <a>Codec String</a>, return
         `false`.
 3. If the User Agent can provide a <a>codec</a> to support all entries of the
     |config|, including applicable default values for keys that are not

--- a/index.src.html
+++ b/index.src.html
@@ -1442,7 +1442,22 @@ Configurations{#configurations}
 <dfn>Check Configuration Support</dfn> (with |config|) {#config-support}
 ------------------------------------------------------------------------
 Run these steps:
-1. If the User Agent can provide a <a>codec</a> to support all entries of the
+1. If |config| is an {{AudioDecoderConfig}} or {{VideoDecoderConfig}} and the
+    User Agent can't provide a <a>codec</a> that can decode the exact profile
+    (where present), level (where present), and constraint bits (where present)
+    indicated by the [[config-codec-string]], return `false`.
+2. If |config| is an {{AudioEncoderConfig}} or {{VideoEncoderConfig}}:
+    1. If [[config-codec-string]] contains a profile and the User Agent can't
+        provide a <a>codec</a> that can encode the exact profile indicated by
+        the [[config-codec-string]], return `false`.
+    2. If [[config-codec-string]] contains a level and the User Agent can't
+        provide a <a>codec</a> that can encode to a level less than or equal to
+        the level indicated by the [[config-codec-string]], return `false`.
+    3. If [[config-codec-string]] contains constraint bits and the User Agent
+        can't provide a <a>codec</a> that can produce an encoded bitstream at
+        least as constrained as indicated by the [[config-codec-string]], return
+        `false`.
+3. If the User Agent can provide a <a>codec</a> to support all entries of the
     |config|, including applicable default values for keys that are not
     included, return `true`.
 
@@ -1570,14 +1585,18 @@ decoding.
 A <dfn>valid codec string</dfn> must meet the following conditions.
 1. Is valid per the relevant codec specification (see examples below).
 2. It describes a single codec.
-3. It is unambiguous about codec profile and level for codecs that define these
-    concepts.
+3. It is unambiguous about codec profile, level, and constraint bits for codecs
+    that define these concepts.
 
 NOTE: In other media specifications, codec strings historically accompanied a
     [=MIME type=] as the "codecs=" parameter
     ({{MediaSource/isTypeSupported()}}, {{HTMLMediaElement/canPlayType()}})
     [[RFC6381]]. In this specification, encoded media is not containerized;
     hence, only the value of the codecs parameter is accepted.
+
+NOTE: Encoders for codecs that define level and constraint bits have flexibility
+    around these parameters, but won't produce bitstreams that have a higher
+    level or are less constrained than requested.
 
 The format and semantics for codec strings are defined by codec registrations
 listed in the [[WEBCODECS-CODEC-REGISTRY]]. A compliant implementation may support any

--- a/index.src.html
+++ b/index.src.html
@@ -1445,17 +1445,17 @@ Run these steps:
 1. If |config| is an {{AudioDecoderConfig}} or {{VideoDecoderConfig}} and the
     User Agent can't provide a <a>codec</a> that can decode the exact profile
     (where present), level (where present), and constraint bits (where present)
-    indicated by the [[config-codec-string]], return `false`.
+    indicated by the {{Codec String}}, return `false`.
 2. If |config| is an {{AudioEncoderConfig}} or {{VideoEncoderConfig}}:
-    1. If [[config-codec-string]] contains a profile and the User Agent can't
+    1. If the {{Codec String}} contains a profile and the User Agent can't
         provide a <a>codec</a> that can encode the exact profile indicated by
-        the [[config-codec-string]], return `false`.
-    2. If [[config-codec-string]] contains a level and the User Agent can't
+        the {{Codec String}}, return `false`.
+    2. If the {{Codec String}} contains a level and the User Agent can't
         provide a <a>codec</a> that can encode to a level less than or equal to
-        the level indicated by the [[config-codec-string]], return `false`.
-    3. If [[config-codec-string]] contains constraint bits and the User Agent
+        the level indicated by the {{Codec String}}, return `false`.
+    3. If the {{Codec String}} contains constraint bits and the User Agent
         can't provide a <a>codec</a> that can produce an encoded bitstream at
-        least as constrained as indicated by the [[config-codec-string]], return
+        least as constrained as indicated by the {{Codec String}}, return
         `false`.
 3. If the User Agent can provide a <a>codec</a> to support all entries of the
     |config|, including applicable default values for keys that are not

--- a/index.src.html
+++ b/index.src.html
@@ -1445,17 +1445,17 @@ Run these steps:
 1. If |config| is an {{AudioDecoderConfig}} or {{VideoDecoderConfig}} and the
     User Agent can't provide a <a>codec</a> that can decode the exact profile
     (where present), level (where present), and constraint bits (where present)
-    indicated by the <a>Codec String</a>, return `false`.
+    indicated by the <a>codec string</a> in |config|.codec, return `false`.
 2. If |config| is an {{AudioEncoderConfig}} or {{VideoEncoderConfig}}:
-    1. If the <a>Codec String</a> contains a profile and the User Agent can't
-        provide a <a>codec</a> that can encode the exact profile indicated by
-        the <a>Codec String</a>, return `false`.
-    2. If the <a>Codec String</a> contains a level and the User Agent can't
-        provide a <a>codec</a> that can encode to a level less than or equal to
-        the level indicated by the <a>Codec String</a>, return `false`.
-    3. If the <a>Codec String</a> contains constraint bits and the User Agent
-        can't provide a <a>codec</a> that can produce an encoded bitstream at
-        least as constrained as indicated by the <a>Codec String</a>, return
+    1. If the <a>codec string</a> in |config|.codec contains a profile and the
+        User Agent can't provide a <a>codec</a> that can encode the exact
+        profile indicated by |config|.codec, return `false`.
+    2. If the <a>codec string</a> in |config|.codec contains a level and the
+        User Agent can't provide a <a>codec</a> that can encode to a level less
+        than or equal to the level indicated by |config|.codec, return `false`.
+    3. If the <a>codec string</a> in |config|.codec contains constraint bits and
+        the User Agent can't provide a <a>codec</a> that can produce an encoded
+        bitstream at least as constrained as indicated by |config|.codec, return
         `false`.
 3. If the User Agent can provide a <a>codec</a> to support all entries of the
     |config|, including applicable default values for keys that are not
@@ -1620,7 +1620,7 @@ To check if an {{AudioDecoderConfig}} is a <dfn>valid AudioDecoderConfig</dfn>,
 
 <dl>
   <dt><dfn dict-member for=AudioDecoderConfig>codec</dfn></dt>
-  <dd>Contains a <a>codec string</a> describing the codec.</dd>
+  <dd>Contains a <a>codec string</a> in |config|.codec describing the codec.</dd>
 
   <dt><dfn dict-member for=AudioDecoderConfig>sampleRate</dfn></dt>
   <dd>The number of frame samples per second.</dd>
@@ -1804,7 +1804,7 @@ To check if a {{VideoEncoderConfig}} is a <dfn>valid VideoEncoderConfig</dfn>,
 
 <dl>
   <dt><dfn dict-member for=VideoEncoderConfig>codec</dfn></dt>
-  <dd>Contains a <a>codec string</a> describing the codec.</dd>
+  <dd>Contains a <a>codec string</a> in |config|.codec describing the codec.</dd>
 
   <dt><dfn dict-member for=VideoEncoderConfig>width</dfn></dt>
   <dd>


### PR DESCRIPTION
I've left off a note about fussiness around parameters, since that's
going to be codec implementation dependent.

Fixes: #253


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/321.html" title="Last updated on Aug 4, 2021, 12:31 AM UTC (9dab195)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/321/03e42e7...9dab195.html" title="Last updated on Aug 4, 2021, 12:31 AM UTC (9dab195)">Diff</a>