### PR TITLE
Add VP9 to the codec registry.

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -53,6 +53,11 @@ jobs:
             echidna_token: ECHIDNA_TOKEN_AV1_REGISTRATION
             build_override: |
               status: NOTE-WD
+          - source: vp9_codec_registration.src.html
+            destination: vp9_codec_registration.html
+            echidna_token: ECHIDNA_TOKEN_AV1_REGISTRATION
+            build_override: |
+              status: NOTE-WD
     steps:
       # See doc at https://github.com/actions/checkout#checkout-v2
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ codec_registry.html
 vorbis_codec_registration.html
 flac_codec_registration.src.html
 av1_codec_registration.src.html
+vp9_codec_registration.src.html
 /index.html
 out/
 

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -157,7 +157,7 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
   <tr>
     <td>vp09.*</td>
     <td>VP9</td>
-    <td>TODO (string)</td>
+    <td>[VP9 codec registration](https://www.w3.org/TR/webcodecs-vp9-codec-registration/) [[WEBCODECS-VP9-CODEC-REGISTRATION]]</td>
   </tr>
 </table>
 

--- a/vp9_codec_registration.src.html
+++ b/vp9_codec_registration.src.html
@@ -1,0 +1,98 @@
+<pre class='metadata'>
+Title: VP9 WebCodecs Registration
+Repository: w3c/webcodecs
+Status: NOTE-ED
+Shortname: webcodecs-vp9-codec-registration
+Level: none
+Group: mediawg
+ED: https://w3c.github.io/webcodecs/vp9_codec_registration.html
+TR: https://www.w3.org/TR/webcodecs-vp9-codec-registration/
+Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
+Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
+Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+
+Abstract: This registration is entered into the [[webcodecs-codec-registry]].
+    It describes, for VP9, the (1) fully qualified codec strings, (2)
+    the {{VideoDecoderConfig.description}} bytes, (3) the codec-specific
+    extensions to {{VideoEncoderConfig}}, (4) the
+    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] bytes, and (5)
+    the meaning of {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=].
+
+    The registration is not intended to include any information on whether a
+    codec format is encumbered by intellectual property claims. Implementers and
+    authors are advised to seek appropriate legal counsel in this matter if they
+    intend to implement or use a specific codec format. Implementers of
+    WebCodecs are not required to support the VP9 codec.
+
+    This registration is non-normative.
+
+Markup Shorthands:css no, markdown yes, dfn yes
+!Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
+!Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
+</pre>
+
+<pre class='anchors'>
+spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
+    type: attribute
+        text: EncodedVideoChunkMetadata.decoderConfig; url: dom-encodedvideochunkmetadata-decoderconfig
+        for: EncodedVideoChunkType; text: key; url: dom-encodedvideochunktype-key
+        text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
+    type: dfn
+        for: EncodedVideoChunk; text: [[internal data]]; url: dom-encodedvideochunk-internal-data-slot
+        for: EncodedVideoChunk; text: [[type]]; url: dom-encodedvideochunk-type-slot
+        for: VideoEncoder; text: [[output callback]]; url: dom-videoencoder-output-callback-slot
+    type: interface
+        text: EncodedVideoChunk; url: encodedvideochunk
+        text: VideoEncoder; url: videoencoder
+    type: dictionary
+        text: VideoEncoderConfig; url: dictdef-videoencoderconfig
+        text: VideoDecoderConfig; url: dictdef-videodecoderconfig
+</pre>
+
+<pre class='biblio'>
+{
+  "VP9": {
+    "href": "https://storage.googleapis.com/downloads.webmproject.org/docs/vp9/vp9-bitstream-specification-v0.6-20160331-draft.pdf",
+    "title": "VP9 Bitstream & Decoding Process Specification",
+    "publisher": "The WebM Project"
+  },
+  "VP9-ISOBMFF": {
+    "href": "https://github.com/webmproject/vp9-dash/blob/master/VPCodecISOMediaFileFormatBinding.md",
+    "title": "VP Codec ISO Media File Format Binding",
+    "publisher": "The WebM Project"
+  }
+}
+</pre>
+
+Fully qualified codec strings {#fully-qualified-codec-strings}
+==============================================================
+
+The codec string begins with the prefix `"vp09."`, followed by a variable length
+suffix as described in the "Codecs Parameter String" Section of [[VP9-ISOBMFF]].
+
+VideoDecoderConfig description {#videodecoderconfig-description}
+================================================================
+
+{{VideoDecoderConfig.description}} is not used for this codec.
+
+EncodedVideoChunk data {#encodedvideochunk-data}
+================================================
+
+{{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] is expected to be
+a frame as described in Section 6 of [[VP9]].
+
+EncodedVideoChunk type {#encodedvideochunk-type}
+================================================
+
+If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
+{{EncodedVideoChunkType/key}}, then the {{EncodedVideoChunk}} is expected to
+contain a frame with a `frame_type` of `KEY_FRAME` as defined in Section
+7.2 of [[VP9]].
+
+Privacy and Security Considerations {#privacy-and-security-considerations}
+==========================================================================
+
+Please refer to the [[WEBCODECS#privacy-considerations|Privacy Considerations]]
+and [[WEBCODECS#security-considerations|Security Considerations]] sections in
+[[WEBCODECS]].


### PR DESCRIPTION
Add VP9 to the codec registry.

As titled. This adds VP9 to the registry following the model used by recent
audio codec registry additions like FLAC.
