### PR TITLE
Update Audio duration references

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1006,6 +1006,9 @@ Algorithms {#audioencoder-algorithms}
             3. Let {{EncodedAudioChunkInit/timestamp}} be the
                 {{AudioData/timestamp}} from the AudioData associated with
                 |output|.
+            4. Let {{EncodedAudioChunkInit/duration}} be the
+                {{AudioData/duration}} from the AudioData associated with
+                |output|.
         2. Let |chunk| be a new {{EncodedAudioChunk}} constructed with
             |chunkInit|.
         3. Let |chunkMetadata| be a new {{EncodedAudioChunkMetadata}}.
@@ -2072,8 +2075,8 @@ EncodedAudioChunk Interface {#encodedaudiochunk-interface}
 interface EncodedAudioChunk {
   constructor(EncodedAudioChunkInit init);
   readonly attribute EncodedAudioChunkType type;
-  readonly attribute long long timestamp;    // microseconds
-  readonly attribute unsigned long duration; // microseconds
+  readonly attribute long long timestamp;          // microseconds
+  readonly attribute unsigned long long? duration; // microseconds
   readonly attribute unsigned long byteLength;
 
   undefined copyTo([AllowShared] BufferSource destination);
@@ -2082,6 +2085,7 @@ interface EncodedAudioChunk {
 dictionary EncodedAudioChunkInit {
   required EncodedAudioChunkType type;
   [EnforceRange] required long long timestamp;    // microseconds
+  [EnforceRange] unsigned long long duration;     // microseconds
   required BufferSource data;
 };
 
@@ -2110,8 +2114,10 @@ enum EncodedAudioChunkType {
 1. Let |chunk| be a new {{EncodedAudioChunk}} object, initialized as follows
     1. Assign `init.type` to {{EncodedAudioChunk/[[type]]}}.
     2. Assign `init.timestamp` to {{EncodedAudioChunk/[[timestamp]]}}.
-    3. Assign a copy of `init.data` to {{EncodedAudioChunk/[[internal data]]}}.
-    4. Assign `init.data.byteLength` to {{EncodedAudioChunk/[[byte length]]}};
+    3. If `init.duration` exists, assign it to
+        {{EncodedAudioChunk/[[timestamp]]}}, or assign `null` otherwise.
+    4. Assign a copy of `init.data` to {{EncodedAudioChunk/[[internal data]]}}.
+    5. Assign `init.data.byteLength` to {{EncodedAudioChunk/[[byte length]]}};
 5. Return |chunk|.
 
 ### Attributes ###{#encodedaudiochunk-attributes}

--- a/index.src.html
+++ b/index.src.html
@@ -2115,7 +2115,7 @@ enum EncodedAudioChunkType {
     1. Assign `init.type` to {{EncodedAudioChunk/[[type]]}}.
     2. Assign `init.timestamp` to {{EncodedAudioChunk/[[timestamp]]}}.
     3. If `init.duration` exists, assign it to
-        {{EncodedAudioChunk/[[timestamp]]}}, or assign `null` otherwise.
+        {{EncodedAudioChunk/[[duration]]}}, or assign `null` otherwise.
     4. Assign a copy of `init.data` to {{EncodedAudioChunk/[[internal data]]}}.
     5. Assign `init.data.byteLength` to {{EncodedAudioChunk/[[byte length]]}};
 5. Return |chunk|.


### PR DESCRIPTION
This PR unifies the units and uses of `duration` duration for `EncodedAudioChunk` and `EncodedAudioChunkInit`.

This aligns the Audio and Video definitions of duration.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 10, 2021, 4:42 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebcodecs%2F03e42e70a03f514c045787fce4a20f74a8c4a0d5%2Findex.src.html&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
Traceback (most recent call last):
  File "/sites/api.csswg.org/bikeshed/bikeshed.py", line 6, in 
    cli.main()
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 466, in main
    handleSpec(options, extras)
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 515, in handleSpec
    lineNumbers=options.lineNumbers,
  File "/sites/api.csswg.org/bikeshed/bikeshed/Spec.py", line 61, in __init__
    self.inputSource = InputSource(inputFilename, chroot=constants.chroot)
  File "/sites/api.csswg.org/bikeshed/bikeshed/InputSource.py", line 51, in __new__
    return UrlInputSource(sourceName, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'chroot'
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webcodecs%23329.)._
</details>
