### PR TITLE
Fix accidental duplication in workflow for codec registry.

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -65,17 +65,12 @@ jobs:
               status: NOTE-WD
           - source: vp9_codec_registration.src.html
             destination: vp9_codec_registration.html
-            echidna_token: ECHIDNA_TOKEN_AV1_REGISTRATION
+            echidna_token: ECHIDNA_TOKEN_VP9_REGISTRATION
             build_override: |
               status: NOTE-WD
           - source: vp8_codec_registration.src.html
             destination: vp8_codec_registration.html
-            echidna_token: ECHIDNA_TOKEN_AV1_REGISTRATION
-            build_override: |
-              status: NOTE-WD
-          - source: vp9_codec_registration.src.html
-            destination: vp9_codec_registration.html
-            echidna_token: ECHIDNA_TOKEN_AV1_REGISTRATION
+            echidna_token: ECHIDNA_TOKEN_VP8_REGISTRATION
             build_override: |
               status: NOTE-WD
     steps:


### PR DESCRIPTION
There were some issues with the merges for the vp8, vp9 additions. Fix the duplication.