### PR TITLE
Make VideoColorSpace constructor argument optional

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3982,7 +3982,7 @@ Video Color Space Interface {#video-color-space-interface}
 <xmp class='idl'>
 [Exposed=(Window,DedicatedWorker)]
 interface VideoColorSpace {
-  constructor(VideoColorSpaceInit init);
+  constructor(optional VideoColorSpaceInit init = {});
 
   readonly attribute VideoColorPrimaries? primaries;
   readonly attribute VideoTransferCharacteristics? transfer;


### PR DESCRIPTION
The constructor takes a `VideoColorSpaceInit` dictionary as input that does not have any required parameter. Quoting from the Web IDL spec, the input "must be specified as optional and have a default value provided. This is to encourage API designs that do not require authors to pass an empty dictionary value when they wish only to use the dictionary’s default values."
https://heycam.github.io/webidl/#idl-operations


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webcodecs/pull/337.html" title="Last updated on Aug 12, 2021, 7:33 AM UTC (81ddaac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/337/2ef514e...tidoust:81ddaac.html" title="Last updated on Aug 12, 2021, 7:33 AM UTC (81ddaac)">Diff</a>