### PR TITLE
Clarify behavior for videoFrame.copyTo() layout offset gaps

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3835,7 +3835,7 @@ dictionary PlaneLayout {
 : <dfn dict-member for=PlaneLayout>offset</dfn>
 :: The offset in bytes where the given plane begins within a {{BufferSource}}.
 
-    NOTE: Authors may use {{PlaneLayout/offset}} to create a gap of bytes
+    NOTE: Authors can use {{PlaneLayout/offset}} to create a gap of bytes
         between planes. Such gaps can be mutated (e.g. zeroed) by the User
         Agent. The specifics of such mutations (if any) are implementer defined.
 

--- a/index.src.html
+++ b/index.src.html
@@ -3835,6 +3835,10 @@ dictionary PlaneLayout {
 : <dfn dict-member for=PlaneLayout>offset</dfn>
 :: The offset in bytes where the given plane begins within a {{BufferSource}}.
 
+    NOTE: Authors may use {{PlaneLayout/offset}} to create a gap of bytes
+        between planes. Such gaps can be mutated (e.g. zeroed) by the User
+        Agent. The specifics of such mutations (if any) are implementer defined.
+
 : <dfn dict-member for=PlaneLayout>stride</dfn>
 :: The number of bytes, including padding, used by each row of the plane within
     a {{BufferSource}}.


### PR DESCRIPTION
After discussion w/ @sandersdan in
 https://bugs.chromium.org/p/chromium/issues/detail?id=1205175

TL;DR: no one should care what happens to the gaps, and leaving it implementer defined affords us flexibility (e.g. leave it up to libYUV).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/354.html" title="Last updated on Sep 9, 2021, 10:28 PM UTC (abab11a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/354/9f27069...abab11a.html" title="Last updated on Sep 9, 2021, 10:28 PM UTC (abab11a)">Diff</a>