### PR TITLE
Add note encouraging VideoEncoderConfig.framerate

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1931,6 +1931,9 @@ To check if a {{VideoEncoderConfig}} is a <dfn>valid VideoEncoderConfig</dfn>,
   <dt><dfn dict-member for=VideoEncoderConfig>bitrate</dfn></dt>
   <dd>
     The average bitrate of the encoded video given in units of bits per second.
+      
+    NOTE: Authors are encouraged to additionally provide a
+    {{VideoEncoderConfig/framerate}} to inform rate control.
   </dd>
 
   <dt><dfn dict-member for=VideoEncoderConfig>framerate</dfn></dt>


### PR DESCRIPTION
Authors who set bitrate should consider also setting framerate. We can generally detect framerate from timestamps, but providing a hint up front avoids assumptions for early frames.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/356.html" title="Last updated on Sep 16, 2021, 12:06 AM UTC (4989ca5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/356/9f27069...4989ca5.html" title="Last updated on Sep 16, 2021, 12:06 AM UTC (4989ca5)">Diff</a>