### PR TITLE
Fix MP3 codec string list formatting

### DIFF
--- a/mp3_codec_registration.src.html
+++ b/mp3_codec_registration.src.html
@@ -63,7 +63,7 @@ Fully qualified codec strings {#fully-qualified-codec-strings}
 
 This codec has multiple equivalent codec strings:
 
-- `"mp3"
+- `"mp3"`
 - `"mp4a.69"`
 - `"mp4a.6B"`
 - `"mp4a.69"`


### PR DESCRIPTION
This PR fixes a minor formatting issue in the codec string list in the MP3 registry entry.