### PR TITLE
Fix link to Vorbis WebCodecs Registration

### DIFF
--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -119,7 +119,9 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
   <tr>
     <td>vorbis</td>
     <td>Vorbis</td>
-    <td>[Vorbis I specification](https://xiph.org/vorbis/doc/Vorbis_I_spec.html) [[WEBCODECS-VORBIS-CODEC-REGISTRATION]]</td>
+    <td>[Vorbis WebCodecs
+      Registration](https://www.w3.org/TR/webcodecs-vorbis-codec-registration/)
+    [[WEBCODECS-VORBIS-CODEC-REGISTRATION]]</td>
   </tr>
   <tr>
     <td>ulaw</td>


### PR DESCRIPTION
I noticed that the WebCodecs registry linked to the Vorbis spec rather than the registry entry.