### PR TITLE
Register alaw, ulaw, and linear pcm. Remove stale inline issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /index.html
+alaw_codec_registration.html
 av1_codec_registration.html
 avc_codec_registration.html
 codec_registry.html
@@ -7,6 +8,7 @@ mp3_codec_registration.html
 aac_codec_registration.html
 opus_codec_registration.html
 out/
+ulaw_codec_registration.html
 vorbis_codec_registration.html
 vp8_codec_registration.html
 vp9_codec_registration.html

--- a/alaw_codec_registration.src.html
+++ b/alaw_codec_registration.src.html
@@ -1,0 +1,92 @@
+<pre class='metadata'>
+Title: A-law PCM WebCodecs Registration
+Repository: w3c/webcodecs
+Status: NOTE-ED
+Shortname: webcodecs-alaw-codec-registration
+Level: none
+Group: mediawg
+ED: https://w3c.github.io/webcodecs/alaw_codec_registration.html
+TR: https://www.w3.org/TR/webcodecs-alaw-codec-registration/
+Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
+Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
+Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+
+Abstract: This registration is entered into the [[webcodecs-codec-registry]].
+    It describes, for A-law encoded PCM, the (1) fully qualified codec strings,
+    (2) the codec-specific {{EncodedAudioChunk}}
+    [=EncodedAudioChunk/[[internal data]]=] bytes, (3) the
+    {{AudioDecoderConfig.description}}, and (4) the values of
+    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+
+    The registration is not intended to include any information on whether a
+    codec format is encumbered by intellectual property claims. Implementers and
+    authors are advised to seek appropriate legal counsel in this matter if they
+    intend to implement or use a specific codec format. Implementers of
+    WebCodecs are not required to support the A-law PCM codec.
+
+    This registration is non-normative.
+
+Markup Shorthands:css no, markdown yes, dfn yes
+!Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
+!Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
+</pre>
+
+<pre class='anchors'>
+spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
+    type: attribute
+        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
+        text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
+        text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
+    type: dfn
+        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
+        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
+        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
+    type: interface
+        text: EncodedAudioChunk; url: encodedaudiochunk
+    type: dictionary
+        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
+        text: AudioEncoderConfig; url: dictdef-audioencoderconfig
+</pre>
+
+<pre class='biblio'>
+{
+  "ITU-G.711": {
+    "href": "https://www.itu.int/rec/T-REC-G.711/",
+    "title": "G.711 : Pulse code modulation (PCM) of voice frequencies",
+    "publisher": "ITU",
+    "date": "November 1988"
+  }
+}
+</pre>
+
+Fully qualified codec strings {#fully-qualified-codec-strings}
+==============================================================
+
+The codec string is `"alaw"`.
+
+EncodedAudioChunk data {#encodedaudiochunk-data}
+================================================
+
+{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
+a sequence of bytes of arbitrary length, where each byte is an A-law
+encoded PCM sample as defined by Tables 1a and 1b in [[ITU-G.711]].
+
+AudioDecoderConfig description {#audiodecoderconfig-description}
+================================================================
+
+An {{AudioDecoderConfig.description}} is expected to be omitted from the
+{{AudioDecoderConfig}}.
+
+EncodedAudioChunk type {#encodedaudiochunk-type}
+================================================
+
+The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
+A-law PCM is always "[=EncodedAudioChunkType/key=]".
+
+Privacy and Security Considerations {#privacy-and-security-considerations}
+==========================================================================
+
+Please refer to the [[WEBCODECS#privacy-considerations|Privacy Considerations]]
+and [[WEBCODECS#security-considerations|Security Considerations]] sections in
+[[WEBCODECS]].

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -81,9 +81,6 @@ Registration Entry Requirements {#registration-entry-requirements}
 Audio Codec Registry {#audio-codec-registry}
 ============================================
 
-ISSUE: Several registrations contain TODOs which should be replaced with links
-    to public specifications covering the mentioned definitions.
-
 <table class='data'>
   <tr>
     <td>**codec string**</td>
@@ -137,9 +134,6 @@ ISSUE: Several registrations contain TODOs which should be replaced with links
 
 Video Codec Registry {#video-codec-registry}
 ============================================
-
-ISSUE: Several registrations contain TODOs which should be replaced with links
-    to public specifications covering the mentioned definitions.
 
 <table class='data'>
   <tr>

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -122,13 +122,17 @@ Audio Codec Registry {#audio-codec-registry}
   </tr>
   <tr>
     <td>ulaw</td>
-    <td>PCM u-law</td>
-    <td>N/A</td>
+    <td>u-law PCM</td>
+    <td>[u-law PCM WebCodecs
+      Registration](https://www.w3.org/TR/webcodecs-ulaw-codec-registration/)
+    [[WEBCODECS-ULAW-CODEC-REGISTRATION]]</td>
   </tr>
   <tr>
     <td>alaw</td>
-    <td>PCM a-law</td>
-    <td>N/A</td>
+    <td>A-law PCM</td>
+    <td>[A-law PCM WebCodecs
+      Registration](https://www.w3.org/TR/webcodecs-alaw-codec-registration/)
+    [[WEBCODECS-ALAW-CODEC-REGISTRATION]]</td>
   </tr>
 </table>
 

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -134,6 +134,13 @@ Audio Codec Registry {#audio-codec-registry}
       Registration](https://www.w3.org/TR/webcodecs-alaw-codec-registration/)
     [[WEBCODECS-ALAW-CODEC-REGISTRATION]]</td>
   </tr>
+  <tr>
+    <td>pcm-*</td>
+    <td>Linear PCM</td>
+    <td>[Linear PCM WebCodecs
+      Registration](https://www.w3.org/TR/webcodecs-pcm-codec-registration/)
+    [[WEBCODECS-ALAW-CODEC-REGISTRATION]]</td>
+  </tr>
 </table>
 
 Video Codec Registry {#video-codec-registry}

--- a/pcm_codec_registration.src.html
+++ b/pcm_codec_registration.src.html
@@ -1,0 +1,117 @@
+<pre class='metadata'>
+Title: Linear PCM WebCodecs Registration
+Repository: w3c/webcodecs
+Status: NOTE-ED
+Shortname: webcodecs-pcm-codec-registration
+Level: none
+Group: mediawg
+ED: https://w3c.github.io/webcodecs/pcm_codec_registration.html
+TR: https://www.w3.org/TR/webcodecs-pcm-codec-registration/
+Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
+Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
+Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+
+Abstract: This registration is entered into the [[webcodecs-codec-registry]].
+    It describes, for Linear PCM, the (1) fully qualified codec strings,
+    (2) the codec-specific {{EncodedAudioChunk}}
+    [=EncodedAudioChunk/[[internal data]]=] bytes, (3) the
+    {{AudioDecoderConfig.description}}, and (4) the values of
+    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+
+    Linear PCM is the [[webcodecs#audio-sample-formats|raw audio format]] used
+    in WebCodecs and does not require decoding. The motivation for registering
+    the Linear PCM codec is to enable passthrough "decoding" of PCM content as
+    an architectural simpliciation for WebCodecs applications.
+
+    The registration is not intended to include any information on whether a
+    codec format is encumbered by intellectual property claims. Implementers and
+    authors are advised to seek appropriate legal counsel in this matter if they
+    intend to implement or use a specific codec format.
+
+    This registration is non-normative.
+
+Markup Shorthands:css no, markdown yes, dfn yes
+!Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
+!Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
+</pre>
+
+<pre class='anchors'>
+spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
+    type: attribute
+        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
+        text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
+        text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
+    type: dfn
+        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
+        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
+        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
+        text: sample; url: sample
+        text: interleaved; url: interleaved
+        text: section on sample magnitude; url: audio-samples-magnitude
+    type: interface
+        text: EncodedAudioChunk; url: encodedaudiochunk
+        text: AudioData; url: audiodata-interface
+    type: dictionary
+        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
+        text: AudioEncoderConfig; url: dictdef-audioencoderconfig
+    type: enum
+        text: AudioSampleFormat; url: enumdef-audiosampleformat
+        text: u8; url: dom-audiosampleformat-u8
+        text: s16; url: dom-audiosampleformat-s16
+        text: s24; url: dom-audiosampleformat-s24
+        text: s32; url: dom-audiosampleformat-s32
+        text: f32; url: dom-audiosampleformat-f32
+</pre>
+
+
+Fully qualified codec strings {#fully-qualified-codec-strings}
+==============================================================
+
+This codec's string begins with the prefix "pcm-", followed by a suffix that
+indicates the sample format. The complete list of strings and associated
+formats is as follows.
+
+* pcm-u8, using format {{u8}}
+* pcm-s16, using format {{s16}}
+* pcm-s24, using three [[WEBIDL#idl-octet|byte]] (24-bit) [=samples=] with
+    [=interleaved=] [[webcodecs#audio-buffer-arrangement|channel arrangement]].
+* pcm-s32, using format {{s32}}
+* pcm-f32, using format {{f32}}
+
+NOTE: [[WEBCODECS]] does not define a 24-bit {{AudioSampleFormat}}. 24-bit
+    samples are permitted within an {{EncodedAudioChunk}}, but such samples will
+    be "decoded" in {{AudioData}} objects as either {{s32}} of {{f32}}. Please
+    see [[WEBCODECS]] [=section on sample magnitude=] for addtional details.
+
+EncodedAudioChunk data {#encodedaudiochunk-data}
+================================================
+
+Linear pulse code modulation (linear PCM) describes a format where the audio
+values are sampled at a regular interval, and where the quantization levels
+between two successive values are linearly uniform.
+
+{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
+a sequence of bytes of arbitrary length, with a [=sample=] occuring every N
+bits, where N is defined by the codec string. For multichannel PCM, [=samples=]
+from different channels are [=interleaved=].
+
+
+AudioDecoderConfig description {#audiodecoderconfig-description}
+================================================================
+
+An {{AudioDecoderConfig.description}} is expected to be omitted from the
+{{AudioDecoderConfig}}.
+
+EncodedAudioChunk type {#encodedaudiochunk-type}
+================================================
+
+The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
+Linear PCM is always "[=EncodedAudioChunkType/key=]".
+
+Privacy and Security Considerations {#privacy-and-security-considerations}
+==========================================================================
+
+Please refer to the [[WEBCODECS#privacy-considerations|Privacy Considerations]]
+and [[WEBCODECS#security-considerations|Security Considerations]] sections in
+[[WEBCODECS]].

--- a/ulaw_codec_registration.src.html
+++ b/ulaw_codec_registration.src.html
@@ -1,0 +1,92 @@
+<pre class='metadata'>
+Title: u-law PCM WebCodecs Registration
+Repository: w3c/webcodecs
+Status: NOTE-ED
+Shortname: webcodecs-ulaw-codec-registration
+Level: none
+Group: mediawg
+ED: https://w3c.github.io/webcodecs/ulaw_codec_registration.html
+TR: https://www.w3.org/TR/webcodecs-ulaw-codec-registration/
+Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
+Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
+Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+
+Abstract: This registration is entered into the [[webcodecs-codec-registry]].
+    It describes, for u-law encoded PCM, the (1) fully qualified codec strings,
+    (2) the codec-specific {{EncodedAudioChunk}}
+    [=EncodedAudioChunk/[[internal data]]=] bytes, (3) the
+    {{AudioDecoderConfig.description}} bytes, and (4) the values of
+    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+
+    The registration is not intended to include any information on whether a
+    codec format is encumbered by intellectual property claims. Implementers and
+    authors are advised to seek appropriate legal counsel in this matter if they
+    intend to implement or use a specific codec format. Implementers of
+    WebCodecs are not required to support the u-law PCM codec.
+
+    This registration is non-normative.
+
+Markup Shorthands:css no, markdown yes, dfn yes
+!Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
+!Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
+</pre>
+
+<pre class='anchors'>
+spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
+    type: attribute
+        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
+        text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
+        text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
+    type: dfn
+        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
+        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
+        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
+    type: interface
+        text: EncodedAudioChunk; url: encodedaudiochunk
+    type: dictionary
+        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
+        text: AudioEncoderConfig; url: dictdef-audioencoderconfig
+</pre>
+
+<pre class='biblio'>
+{
+  "ITU-G.711": {
+    "href": "https://www.itu.int/rec/T-REC-G.711/",
+    "title": "G.711 : Pulse code modulation (PCM) of voice frequencies",
+    "publisher": "ITU",
+    "date": "November 1988"
+  }
+}
+</pre>
+
+Fully qualified codec strings {#fully-qualified-codec-strings}
+==============================================================
+
+The codec string is `"ulaw"`.
+
+EncodedAudioChunk data {#encodedaudiochunk-data}
+================================================
+
+{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
+a sequence of bytes of arbitrary length, where each byte is a u-law
+encoded PCM sample as defined by Table 2a and 2b in [[ITU-G.711]].
+
+AudioDecoderConfig description {#audiodecoderconfig-description}
+================================================================
+
+An {{AudioDecoderConfig.description}} is expected to be omitted from the
+{{AudioDecoderConfig}}.
+
+EncodedAudioChunk type {#encodedaudiochunk-type}
+================================================
+
+The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
+u-law PCM is always "[=EncodedAudioChunkType/key=]".
+
+Privacy and Security Considerations {#privacy-and-security-considerations}
+==========================================================================
+
+Please refer to the [[WEBCODECS#privacy-considerations|Privacy Considerations]]
+and [[WEBCODECS#security-considerations|Security Considerations]] sections in
+[[WEBCODECS]].


### PR DESCRIPTION
Our earlier thinking was that alaw and ulaw did not needing registration documents, as they have simple codec strings and no need for AudioDecoderConfig.description bytes. But we've since used the registry to define the details of EncodedAudioChunk's internal data, so registration documents are added to provide those details. 

With this, the The TODOs are now all addressed, so  inline ISSUEs can be removed. 
