### PR TITLE
Cleanup registration requirements/ordering.

### DIFF
--- a/aac_codec_registration.src.html
+++ b/aac_codec_registration.src.html
@@ -12,10 +12,11 @@ Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for AAC, (1) the fully qualified codec strings, (2)
-    the {{AudioDecoderConfig.description}} bytes, (3) the codec-specific
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] bytes, and (4)
-    the values of {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+    It describes, for AAC, the (1) fully qualified codec strings, (2) the
+    codec-specific {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=]
+    bytes, (3) the {{AudioDecoderConfig.description}} bytes, (4) the values of
+    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=], and (5) the
+    codec-specific extensions to {{AudioEncoderConfig}}
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -71,6 +72,18 @@ This codec has multiple possible codec strings:
 - `"mp4a.40.29"` — MPEG-4 HE-AAC v2 (AAC LC + SBR + PS)
 - `"mp4a.67"` — MPEG-2 AAC LC
 
+EncodedAudioChunk data {#encodedaudiochunk-data}
+================================================
+
+If the bitstream is in {{AacBitstreamFormat/adts}} format, the
+[=EncodedAudioChunk/[[internal data]]=] of {{EncodedAudioChunk}}s are expected
+to be an ADTS frame, as described in section 1.A.3.2 of [[iso14496-3]].
+
+If the bitstream is in {{AacBitstreamFormat/aac}} format, the
+[=EncodedAudioChunk/[[internal data]]=] of {{EncodedAudioChunk}}s are expected
+to be a raw AAC frame (syntax element `raw_data_block()`), as described in
+section 4.4.2.1 of [[iso14496-3]].
+
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
@@ -84,82 +97,6 @@ assumed to be in {{AacBitstreamFormat/adts}} format.
 The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.channelCount}}
 members are ignored.
 
-AudioEncoderConfig extensions {#audioencoderconfig-extensions}
-==============================================================
-
-<pre class='idl'>
-<xmp>
-partial dictionary AudioEncoderConfig {
-  AacEncoderConfig aac;
-};
-</xmp>
-</pre>
-
-<dl>
-  <dt><dfn dict-member for=AudioEncoderConfig>aac</dfn></dt>
-  <dd>
-    Contains codec specific configuration options for the AAC codec.
-  </dd>
-</dl>
-
-AacEncoderConfig {#aac-encoder-config}
---------------------------------------
-
-<pre class='idl'>
-<xmp>
-dictionary AacEncoderConfig {
-  AacBitstreamFormat format = "aac";
-};
-</xmp>
-</pre>
-
-<dl>
-  <dt><dfn dict-member for=AacEncoderConfig>format</dfn></dt>
-  <dd>
-    Configures the format of output {{EncodedAudioChunk}}s. See
-    {{AacBitstreamFormat}}.
-  </dd>
-</dl>
-
-AacBitstreamFormat {#aac-bitstream-format}
-------------------------------------------
-<pre class='idl'>
-<xmp>
-enum AacBitstreamFormat {
-  "aac",
-  "adts",
-};
-</xmp>
-</pre>
-
-The {{AacBitstreamFormat}} determines the location of the metadata necessary to decode the encoded audio stream.
-
-<dl>
-  <dt><dfn enum-value for=AacBitstreamFormat>aac</dfn></dt>
-  <dd>
-    The metadata of the encoded audio stream are provided at configuration via
-    {{AudioDecoderConfig.description}}.
-  </dd>
-  <dt><dfn enum-value for=AacBitstreamFormat>adts</dfn></dt>
-  <dd>
-    The metadata of the encoded audio stream are provided in each ADTS frame,
-    and therefore no {{AudioDecoderConfig.description}} is necessary.
-</dl>
-
-
-EncodedAudioChunk data {#encodedaudiochunk-data}
-================================================
-
-If the bitstream is in {{AacBitstreamFormat/adts}} format, the
-[=EncodedAudioChunk/[[internal data]]=] of {{EncodedAudioChunk}}s are expected
-to be an ADTS frame, as described in section 1.A.3.2 of [[iso14496-3]].
-
-If the bitstream is in {{AacBitstreamFormat/aac}} format, the
-[=EncodedAudioChunk/[[internal data]]=] of {{EncodedAudioChunk}}s are expected
-to be a raw AAC frame (syntax element `raw_data_block()`), as described in
-section 4.4.2.1 of [[iso14496-3]].
-
-
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================
 
@@ -169,6 +106,68 @@ AAC is always "[=EncodedAudioChunkType/key=]".
 NOTE: Once the initialization has succeeded, any AAC packet can be decoded at
     any time without error, but this might not result in the expected audio
     output.
+
+    AudioEncoderConfig extensions {#audioencoderconfig-extensions}
+    ==============================================================
+
+    <pre class='idl'>
+    <xmp>
+    partial dictionary AudioEncoderConfig {
+      AacEncoderConfig aac;
+    };
+    </xmp>
+    </pre>
+
+    <dl>
+      <dt><dfn dict-member for=AudioEncoderConfig>aac</dfn></dt>
+      <dd>
+        Contains codec specific configuration options for the AAC codec.
+      </dd>
+    </dl>
+
+    AacEncoderConfig {#aac-encoder-config}
+    --------------------------------------
+
+    <pre class='idl'>
+    <xmp>
+    dictionary AacEncoderConfig {
+      AacBitstreamFormat format = "aac";
+    };
+    </xmp>
+    </pre>
+
+    <dl>
+      <dt><dfn dict-member for=AacEncoderConfig>format</dfn></dt>
+      <dd>
+        Configures the format of output {{EncodedAudioChunk}}s. See
+        {{AacBitstreamFormat}}.
+      </dd>
+    </dl>
+
+    AacBitstreamFormat {#aac-bitstream-format}
+    ------------------------------------------
+    <pre class='idl'>
+    <xmp>
+    enum AacBitstreamFormat {
+      "aac",
+      "adts",
+    };
+    </xmp>
+    </pre>
+
+    The {{AacBitstreamFormat}} determines the location of the metadata necessary to decode the encoded audio stream.
+
+    <dl>
+      <dt><dfn enum-value for=AacBitstreamFormat>aac</dfn></dt>
+      <dd>
+        The metadata of the encoded audio stream are provided at configuration via
+        {{AudioDecoderConfig.description}}.
+      </dd>
+      <dt><dfn enum-value for=AacBitstreamFormat>adts</dfn></dt>
+      <dd>
+        The metadata of the encoded audio stream are provided in each ADTS frame,
+        and therefore no {{AudioDecoderConfig.description}} is necessary.
+    </dl>
 
 Privacy and Security Considerations {#privacy-and-security-considerations}
 ==========================================================================

--- a/av1_codec_registration.src.html
+++ b/av1_codec_registration.src.html
@@ -12,11 +12,11 @@ Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for AV1, the (1) fully qualified codec strings, (2)
-    the {{VideoDecoderConfig.description}} bytes, (3) the codec-specific
-    extensions to {{VideoEncoderConfig}}, (4) the
-    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] bytes, and (5)
-    the meaning of {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=].
+    It describes, for AV1, the (1) fully qualified codec strings,
+    (2) the codec-specific {{EncodedVideoChunk}}
+    [=EncodedVideoChunk/[[internal data]]=] bytes, (3) the
+    {{VideoDecoderConfig.description}} bytes, and (4) the values of
+    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=].
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -71,17 +71,17 @@ Fully qualified codec strings {#fully-qualified-codec-strings}
 The codec string begins with the prefix `"av01."`, followed by a variable length
 suffix as described in Section 5 of [[AV1-ISOBMFF]].
 
-VideoDecoderConfig description {#videodecoderconfig-description}
-================================================================
-
-{{VideoDecoderConfig.description}} is not used for this codec.
-
 EncodedVideoChunk data {#encodedvideochunk-data}
 ================================================
 
 {{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] is expected to be
 either an "open bit-stream unit" (OBU) or "low-overhead OBU" as described in
 Section 5 of [[AV1]].
+
+VideoDecoderConfig description {#videodecoderconfig-description}
+================================================================
+
+{{VideoDecoderConfig.description}} is not used for this codec.
 
 EncodedVideoChunk type {#encodedvideochunk-type}
 ================================================

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -12,11 +12,12 @@ Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for AVC (H.264), the (1) fully qualified codec strings, (2)
-    the {{VideoDecoderConfig.description}} bytes, (3) the codec-specific
-    extensions to {{VideoEncoderConfig}}, (4) the
-    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] bytes, and (5)
-    the meaning of {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=].
+    It describes, for AVC (H.264), the (1) fully qualified codec strings,
+    (2) the codec-specific {{EncodedVideoChunk}}
+    [=EncodedVideoChunk/[[internal data]]=] bytes, (3) the
+    {{VideoDecoderConfig.description}} bytes, (4) the values of
+    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=], and (5) the
+    codec-specific extensions to {{VideoEncoderConfig}}
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -71,7 +72,27 @@ Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
 The codec string begins with the prefix "avc1." or "avc3.", with a suffix of 6
-characters as described respectively in Section 3.4 of [[rfc6381]] and Section 5.4.1 of [[iso14496-15]].
+characters as described respectively in Section 3.4 of [[rfc6381]] and Section
+5.4.1 of [[iso14496-15]].
+
+EncodedVideoChunk data {#encodedvideochunk-data}
+================================================
+
+{{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] is expected to be
+an access unit as defined in [[ITU-T-REC-H.264]] section 7.4.1.2.
+
+NOTE: An access unit contains exactly one primary coded picture.
+
+If the bitstream is in {{AvcBitstreamFormat/avc}} format,
+[=EncodedVideoChunk/[[internal data]]=] is assumed to be in canonical format, as
+defined in [[iso14496-15]] section 5.3.2.
+
+If the bitstream is in {{AvcBitstreamFormat/annexb}} format,
+[=EncodedVideoChunk/[[internal data]]=] is assumed to be in in Annex B format,
+as defined in [[ITU-T-REC-H.264]] Annex B.
+
+NOTE: Since [=EncodedVideoChunk/[[internal data]]=] is inherently byte-aligned,
+    implementations are not required to recover byte-alignment.
 
 VideoDecoderConfig description {#videodecoderconfig-description}
 ================================================================
@@ -91,6 +112,25 @@ NOTE: "annexb" format is described in greater detail by [[ITU-T-REC-H.264]],
     Annex B. This format is commonly used in live-streaming applications, where
     including the SPS and PPS data periodically allows users to easily start
     from the middle of the stream.
+
+EncodedVideoChunk type {#encodedvideochunk-type}
+================================================
+
+If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
+{{EncodedVideoChunkType/key}}, and the bitstream is in
+{{AvcBitstreamFormat/avc}} format, then the {{EncodedVideoChunk}} is expected to
+contain a primary coded picture that is an instantaneous decoding refresh (IDR)
+picture.
+
+NOTE: If the bitstream is in {{AvcBitstreamFormat/avc}} format, parameter sets
+    necessary for decoding are included in {{VideoDecoderConfig.description}}.
+
+If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
+{{EncodedVideoChunkType/key}}, and the bitstream is in
+{{AvcBitstreamFormat/annexb}} format, then the {{EncodedVideoChunk}} is expected
+to contain both a primary coded picture that is an instantaneous decoding
+refresh (IDR) picture, and all parameter sets necessary to decode all video data
+NAL units in the {{EncodedVideoChunk}}.
 
 VideoEncoderConfig extensions {#videoencoderconfig-extensions}
 ==============================================================
@@ -167,44 +207,6 @@ SPS and PPS are described in greater detail in sections G.3.41 and G.3.55 of
         section 5.3.3.1. This format is commonly used in .MP4 files, where the
         player generally has random access to the media data.
 </dl>
-
-EncodedVideoChunk data {#encodedvideochunk-data}
-================================================
-
-{{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] is expected to be
-an access unit as defined in [[ITU-T-REC-H.264]] section 7.4.1.2.
-
-NOTE: An access unit contains exactly one primary coded picture.
-
-If the bitstream is in {{AvcBitstreamFormat/avc}} format,
-[=EncodedVideoChunk/[[internal data]]=] is assumed to be in canonical format, as
-defined in [[iso14496-15]] section 5.3.2.
-
-If the bitstream is in {{AvcBitstreamFormat/annexb}} format,
-[=EncodedVideoChunk/[[internal data]]=] is assumed to be in in Annex B format,
-as defined in [[ITU-T-REC-H.264]] Annex B.
-
-NOTE: Since [=EncodedVideoChunk/[[internal data]]=] is inherently byte-aligned,
-    implementations are not required to recover byte-alignment.
-
-EncodedVideoChunk type {#encodedvideochunk-type}
-================================================
-
-If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
-{{EncodedVideoChunkType/key}}, and the bitstream is in
-{{AvcBitstreamFormat/avc}} format, then the {{EncodedVideoChunk}} is expected to
-contain a primary coded picture that is an instantaneous decoding refresh (IDR)
-picture.
-
-NOTE: If the bitstream is in {{AvcBitstreamFormat/avc}} format, parameter sets
-    necessary for decoding are included in {{VideoDecoderConfig.description}}.
-
-If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
-{{EncodedVideoChunkType/key}}, and the bitstream is in
-{{AvcBitstreamFormat/annexb}} format, then the {{EncodedVideoChunk}} is expected
-to contain both a primary coded picture that is an instantaneous decoding
-refresh (IDR) picture, and all parameter sets necessary to decode all video data
-NAL units in the {{EncodedVideoChunk}}.
 
 Privacy and Security Considerations {#privacy-and-security-considerations}
 ==========================================================================

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -39,37 +39,49 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: attribute
         text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
         text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
-        text: VideoEncoderConfig; url: video-encoder-config
-        text: AudioEncoderConfig; url: audio-encoder-config
+    type: dfn
+        for: EncodedVideoChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
+    type: interface
+        text: EncodedAudioChunk; url: encodedaudiochunk
+        text: EncodedVideoChunk; url: encodedvideochunk
+    type: dictionary
+        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
+        text: AudioEncoderConfig; url: dictdef-audioencoderconfig
+        text: VideoDecoderConfig; url: dictdef-videodecoderconfig
+        text: VideoEncoderConfig; url: dictdef-videoencoderconfig
 </pre>
 
 
 Organization {#organization}
 ============================
 
-This registry maintains a mapping between codec strings and definitions for (1)
-fully qualified codec string values, (2) codec-specific values for
-{{VideoDecoderConfig.description}} and
-{{AudioDecoderConfig.description}}, and (3) codec-specific members of
-the {{VideoEncoderConfig}} and {{AudioEncoderConfig}}
-dictionaries.
+This registry maintains a mapping between codec strings and registration
+specifications as described below.
 
 Registration Entry Requirements {#registration-entry-requirements}
 ==================================================================
 
-1. Each entry must include a unique codec string and a common name string.
-2. If the codec string contains a fixed prefix with variable suffix values, the
-    suffix must be represented by an asterisk and the registration must link to
-    a public specification describing how to fully qualify the variable portion
-    of the string.
-3. If the described codec requires that codec-specific bytes be provided as
-    part of the {{VideoDecoderConfig.description}} or the
-    {{AudioDecoderConfig.description}}, the registration must link to
-    a public specification describing how to populate these fields.
-4. If the {{AudioEncoderConfig}} or {{VideoEncoderConfig}}
-    dictionaries are extended with members specific to the described codec, the
-    registration must link to a public specification describing how to populate
-    these fields.
+1. Each entry must include a unique codec string, a common name string, and a
+    link to a public specification.
+2. The codec string must be crafted as follows:
+    1. If the codec string contains a fixed prefix with variable suffix values,
+        the suffix must be represented by an asterisk and the registration's
+        public specification must describe how to fully qualify the variable
+        portion of the string.
+    2. Otherwise, if the codec is recognized by multiple strings, a single
+        preferred string should be listed and the registration's specification
+        must list the other allowed strings.
+    3. Otherwise, the codec is identified by a simple fixed string.
+3. Each registration's specification must include a sequence of sections
+    describing:
+    1. Recognized codec strings
+    2. {{EncodedAudioChunk}} or {{EncodedVideoChunk}} internal data
+    3. {{AudioDecoderConfig}} or {{VideoDecoderConfig}} description bytes
+    4. Expectations for {{EncodedAudioChunk}} or {{EncodedVideoChunk}}
+        [=EncodedVideoChunk/[[type]]=]
+3. Where applicable, a registration specification may include a section
+    describing extensions to {{VideoEncoderConfig}} or {{AudioEncoderConfig}}
+    dictionaries.
 4. Candidate entries must be announced by filing an issue in the
     [WebCodecs GitHub issue tracker](https://github.com/w3c/webcodecs/issues/)
     so they can be discussed and evaluated for compliance before being added to

--- a/flac_codec_registration.src.html
+++ b/flac_codec_registration.src.html
@@ -12,10 +12,11 @@ Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for FLAC, the (1) fully qualified codec strings, (2)
-    the {{AudioDecoderConfig.description}} bytes, (3) the codec-specific
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] bytes, and (4)
-    the values of {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+    It describes, for FLAC, the (1) fully qualified codec strings,
+    (2) the codec-specific {{EncodedAudioChunk}}
+    [=EncodedAudioChunk/[[internal data]]=] bytes, (3) the
+    {{AudioDecoderConfig.description}} bytes, and (4) the values of
+    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -12,10 +12,11 @@ Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for Opus, the (1) fully qualified codec strings, (2)
-    the {{AudioDecoderConfig.description}} bytes, (3) the codec-specific
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] bytes, and (4)
-    the values of {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+    It describes, for Opus, the (1) fully qualified codec strings, (2) the
+    codec-specific {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=]
+    bytes, (3) the {{AudioDecoderConfig.description}} bytes, (4) the values of
+    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=], and (5) the
+    codec-specific extensions to {{AudioEncoderConfig}}
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -95,6 +96,15 @@ to be in {{OpusBitstreamFormat/ogg}} format.
 If an {{AudioDecoderConfig.description}} has not been set, the bitstream is
 assumed to be in {{OpusBitstreamFormat/opus}} format.
 
+EncodedAudioChunk type {#encodedaudiochunk-type}
+================================================
+
+The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
+Opus is always "[=EncodedAudioChunkType/key=]".
+
+NOTE: Once the initialization has succeeded, any packet can be decoded at any
+time without error, but this might not result in the expected audio output.
+
 AudiEncoderConfig extensions {#audioencoderconfig-extensions}
 =============================================================
 
@@ -158,16 +168,6 @@ encoded audio stream.
     {{AudioDecoderConfig.description}}.
   </dd>
 </dl>
-
-
-EncodedAudioChunk type {#encodedaudiochunk-type}
-================================================
-
-The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
-Opus is always "[=EncodedAudioChunkType/key=]".
-
-NOTE: Once the initialization has succeeded, any packet can be decoded at any
-time without error, but this might not result in the expected audio output.
 
 Privacy and Security Considerations {#privacy-and-security-considerations}
 ==========================================================================

--- a/vorbis_codec_registration.src.html
+++ b/vorbis_codec_registration.src.html
@@ -12,10 +12,11 @@ Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for Vorbis, the (1) fully qualified codec strings, (2)
-    the {{AudioDecoderConfig.description}} bytes, (3) the codec-specific
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] bytes, and (4)
-    the values of {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+    It describes, for Vorbis, the (1) fully qualified codec strings,
+    (2) the codec-specific {{EncodedAudioChunk}}
+    [=EncodedAudioChunk/[[internal data]]=] bytes, (3) the
+    {{AudioDecoderConfig.description}} bytes, and (4) the values of
+    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and

--- a/vp8_codec_registration.src.html
+++ b/vp8_codec_registration.src.html
@@ -12,11 +12,11 @@ Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for VP8, the (1) fully qualified codec strings, (2)
-    the {{VideoDecoderConfig.description}} bytes, (3) the codec-specific
-    extensions to {{VideoEncoderConfig}}, (4) the
-    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] bytes, and (5)
-    the meaning of {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=].
+    It describes, for VP8, the (1) fully qualified codec strings,
+    (2) the codec-specific {{EncodedVideoChunk}}
+    [=EncodedVideoChunk/[[internal data]]=] bytes, (3) the
+    {{VideoDecoderConfig.description}} bytes, and (4) the values of
+    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=].
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -65,16 +65,16 @@ Fully qualified codec strings {#fully-qualified-codec-strings}
 
 The codec string is `"vp8"`.
 
-VideoDecoderConfig description {#videodecoderconfig-description}
-================================================================
-
-{{VideoDecoderConfig.description}} is not used for this codec.
-
 EncodedVideoChunk data {#encodedvideochunk-data}
 ================================================
 
 {{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] is expected to be
 a frame as described in Section 4 and Annex A of [[VP8]].
+
+VideoDecoderConfig description {#videodecoderconfig-description}
+================================================================
+
+{{VideoDecoderConfig.description}} is not used for this codec.
 
 EncodedVideoChunk type {#encodedvideochunk-type}
 ================================================

--- a/vp9_codec_registration.src.html
+++ b/vp9_codec_registration.src.html
@@ -12,11 +12,11 @@ Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for VP9, the (1) fully qualified codec strings, (2)
-    the {{VideoDecoderConfig.description}} bytes, (3) the codec-specific
-    extensions to {{VideoEncoderConfig}}, (4) the
-    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] bytes, and (5)
-    the meaning of {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=].
+    It describes, for VP9, the (1) fully qualified codec strings,
+    (2) the codec-specific {{EncodedVideoChunk}}
+    [=EncodedVideoChunk/[[internal data]]=] bytes, (3) the
+    {{VideoDecoderConfig.description}} bytes, and (4) the values of
+    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=].
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -71,16 +71,16 @@ Fully qualified codec strings {#fully-qualified-codec-strings}
 The codec string begins with the prefix `"vp09."`, followed by a variable length
 suffix as described in the "Codecs Parameter String" Section of [[VP9-ISOBMFF]].
 
-VideoDecoderConfig description {#videodecoderconfig-description}
-================================================================
-
-{{VideoDecoderConfig.description}} is not used for this codec.
-
 EncodedVideoChunk data {#encodedvideochunk-data}
 ================================================
 
 {{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] is expected to be
 a frame as described in Section 6 of [[VP9]].
+
+VideoDecoderConfig description {#videodecoderconfig-description}
+================================================================
+
+{{VideoDecoderConfig.description}} is not used for this codec.
 
 EncodedVideoChunk type {#encodedvideochunk-type}
 ================================================


### PR DESCRIPTION
Details of registrations are unchanged. This just moves the sections around to arrive at a uniform ordering. It also includes an update to  the registry requirements to describe that ordering.