### PR TITLE
Export dfns for valid audio and video decoder cfgs

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1682,7 +1682,7 @@ dictionary AudioDecoderConfig {
 };
 </xmp>
 
-To check if an {{AudioDecoderConfig}} is a <dfn>valid AudioDecoderConfig</dfn>,
+To check if an {{AudioDecoderConfig}} is a <dfn export>valid AudioDecoderConfig</dfn>,
     run these steps:
 1. If codec is not a <a>valid codec string</a>, return `false`.
 2. Return `true`.
@@ -1724,7 +1724,7 @@ dictionary VideoDecoderConfig {
 };
 </xmp>
 
-To check if a {{VideoDecoderConfig}} is a <dfn>valid VideoDecoderConfig</dfn>,
+To check if a {{VideoDecoderConfig}} is a <dfn export>valid VideoDecoderConfig</dfn>,
 run these steps:
 1. If {{VideoDecoderConfig/codec}} is not a <a>valid codec string</a>, return
     `false`.


### PR DESCRIPTION
MSE-for-WebCodecs feature specification [1] needs to normatively
reference these concepts.

[1] https://github.com/w3c/media-source/issues/184


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wolenetz/webcodecs/pull/372.html" title="Last updated on Sep 30, 2021, 11:49 PM UTC (c33f68b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/372/206b991...wolenetz:c33f68b.html" title="Last updated on Sep 30, 2021, 11:49 PM UTC (c33f68b)">Diff</a>