### PR TITLE
Move MP4 demuxe/decode demo to workers

### DIFF
--- a/samples/mp4-decode/demux_decode_worker.js
+++ b/samples/mp4-decode/demux_decode_worker.js
@@ -1,21 +1,49 @@
 importScripts('./mp4box.all.min.js');
 importScripts('./mp4_demuxer.js');
 
-let demuxer = new MP4Demuxer("/webcodecs/samples/media/bbb.mp4");
+self.addEventListener('message', function(e) {
+  let offscreen = e.data.canvas;
+  let ctx = offscreen.getContext('2d');
+  let startTime = 0;
+  let frameCount = 0;
 
-let decoder = new VideoDecoder({
-    output: f => {
-      self.postMessage({ type:"frame", frame: f });
-      f.close();
+  let demuxer = new MP4Demuxer("/webcodecs/samples/media/bbb.mp4");
+
+  function getFrameStats() {
+      let now = performance.now();
+      let fps = "";
+
+      if (frameCount++) {
+        let elapsed = now - startTime;
+        fps = " (" + (1000.0 * frameCount / (elapsed)).toFixed(0) + " fps)"
+      } else {
+        // This is the first frame.
+        startTime = now;
+      }
+
+      return "Extracted " + frameCount + " frames" + fps;
+  }
+
+  let decoder = new VideoDecoder({
+    output : frame => {
+      ctx.drawImage(frame, 0, 0, offscreen.width, offscreen.height);
+
+      // Close ASAP.
+      frame.close();
+
+      // Draw some optional stats.
+      ctx.font = '35px sans-serif';
+      ctx.fillStyle = "#ffffff";
+      ctx.fillText(getFrameStats(), 40, 40, offscreen.width);
     },
-    error: e => console.error(e),
-});
+    error : e => console.error(e),
+  });
 
-demuxer.getConfig().then((config) => {
-  self.postMessage({ type:"config", config: config });
+  demuxer.getConfig().then((config) => {
+    offscreen.height = config.codedHeight;
+    offscreen.width = config.codedWidth;
 
-  decoder.configure(config);
-  demuxer.start((chunk) => {
-    decoder.decode(chunk);
-  })
-});
+    decoder.configure(config);
+    demuxer.start((chunk) => { decoder.decode(chunk); })
+  });
+})

--- a/samples/mp4-decode/demux_decode_worker.js
+++ b/samples/mp4-decode/demux_decode_worker.js
@@ -1,0 +1,21 @@
+importScripts('./mp4box.all.min.js');
+importScripts('./mp4_demuxer.js');
+
+let demuxer = new MP4Demuxer("/webcodecs/samples/media/bbb.mp4");
+
+let decoder = new VideoDecoder({
+    output: f => {
+      self.postMessage({ type:"frame", frame: f });
+      f.close();
+    },
+    error: e => console.error(e),
+});
+
+demuxer.getConfig().then((config) => {
+  self.postMessage({ type:"config", config: config });
+
+  decoder.configure(config);
+  demuxer.start((chunk) => {
+    decoder.decode(chunk);
+  })
+});

--- a/samples/mp4-decode/index.html
+++ b/samples/mp4-decode/index.html
@@ -9,9 +9,6 @@
   <p>
     This demo extracts all frames from an MP4 file and renders them to a canvas as fast as possible. It uses <a href="https://github.com/gpac/mp4box.js/">mp4box.js</a> to parse and demux the file.
   </p>
-  <p>
-    Frames extracted: <span id="frameStats"></span>
-  </p>
   <canvas></canvas>
 </body>
 
@@ -19,44 +16,14 @@
   var demuxDecodeWorker;
 
   var canvas = document.querySelector("canvas");
-  var ctx = canvas.getContext('2d');
+  var offscreen = canvas.transferControlToOffscreen();
   document.body.appendChild(canvas);
 
   var frameCount = 0;
   var startTime;
 
-  async function onMessage(e) {
-    if (e.data.type == "config") {
-      let config = e.data.config;
-      canvas.height = config.codedHeight;
-      canvas.width = config.codedWidth;
-      return;
-    }
-
-    console.assert(e.data.type == "frame");
-
-    let frame = e.data.frame;
-    let now = performance.now();
-
-    ctx.drawImage(frame, 0, 0, canvas.width, canvas.height);
-    frame.close();
-
-    let fps = "";
-    if(frameCount++) {
-      let elapsed = now - startTime;
-      fps = " (" + (1000.0*frameCount/(elapsed)).toFixed(0) + " fps)"
-    } else {
-      // This is the first frame.
-      startTime = now;
-    }
-
-    document.getElementById("frameStats").innerText = frameCount + fps;
-  }
-
   demuxDecodeWorker = new Worker("./demux_decode_worker.js");
-
-  demuxDecodeWorker.addEventListener('message', onMessage);
-  window.demuxDecodeWorker = demuxDecodeWorker;
+  demuxDecodeWorker.postMessage({ canvas: offscreen}, [offscreen]);
 </script>
 
 </html>

--- a/samples/mp4-decode/index.html
+++ b/samples/mp4-decode/index.html
@@ -29,7 +29,7 @@
     if (e.data.type == "config") {
       let config = e.data.config;
       canvas.height = config.codedHeight;
-      canvas.width = config.codedwidth;
+      canvas.width = config.codedWidth;
       return;
     }
 

--- a/samples/mp4-decode/index.html
+++ b/samples/mp4-decode/index.html
@@ -15,11 +15,8 @@
   <canvas></canvas>
 </body>
 
-<script src="mp4box.all.min.js"></script>
-
 <script type="module">
-  import {MP4Demuxer} from "./mp4_demuxer.js";
-  let demuxer = new MP4Demuxer("/webcodecs/samples/media/bbb.mp4");
+  var demuxDecodeWorker;
 
   var canvas = document.querySelector("canvas");
   var ctx = canvas.getContext('2d');
@@ -28,7 +25,17 @@
   var frameCount = 0;
   var startTime;
 
-  async function onFrame(frame) {
+  async function onMessage(e) {
+    if (e.data.type == "config") {
+      let config = e.data.config;
+      canvas.height = config.codedHeight;
+      canvas.width = config.codedwidth;
+      return;
+    }
+
+    console.assert(e.data.type == "frame");
+
+    let frame = e.data.frame;
     let now = performance.now();
 
     ctx.drawImage(frame, 0, 0, canvas.width, canvas.height);
@@ -46,22 +53,10 @@
     document.getElementById("frameStats").innerText = frameCount + fps;
   }
 
-  let decoder = new VideoDecoder({
-    output: onFrame,
-    error: e => console.error(e),
-  });
+  demuxDecodeWorker = new Worker("./demux_decode_worker.js");
 
-  demuxer.getConfig().then((config) => {
-    canvas.height = config.codedHeight;
-    canvas.width = config.codedWidth;
-
-    decoder.configure(config);
-    demuxer.start((chunk) => {
-      decoder.decode(chunk);
-    })
-  });
-
-  window.decoder = decoder;
+  demuxDecodeWorker.addEventListener('message', onMessage);
+  window.demuxDecodeWorker = demuxDecodeWorker;
 </script>
 
 </html>

--- a/samples/mp4-decode/mp4_demuxer.js
+++ b/samples/mp4-decode/mp4_demuxer.js
@@ -111,7 +111,7 @@ class Writer {
   }
 }
 
-export class MP4Demuxer {
+class MP4Demuxer {
   constructor(uri) {
     this.source = new MP4Source(uri);
   }
@@ -140,7 +140,6 @@ export class MP4Demuxer {
     for (i = 0; i < avccBox.SPS.length; i++) {
       writer.writeUint16(avccBox.SPS[i].length);
       writer.writeUint8Array(avccBox.SPS[i].nalu);
-      window.temp = avccBox.SPS[i].nalu;
     }
 
     writer.writeUint8(avccBox.nb_PPS_nalus);


### PR DESCRIPTION
This PR moves the MP4 demux+decode demo to fetch, demux and decode in a worker, posting frames back to the main thread.

This change is done in order to align our demos with the recommended best practice of offloading webcodecs from the main window to workers.