### PR TITLE
Define importing VideoFrame into WebGPU

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3788,7 +3788,7 @@ objects, which can be read from WebGPU shaders.
 The definition of the {{GPUExternalTextureDescriptor/source}} member of
 {{GPUExternalTextureDescriptor}} is modified to allow {{VideoFrame}}:
 
-<xmp>
+<xmp class='idl'>
 partial dictionary GPUExternalTextureDescriptor {
     required (HTMLVideoElement or VideoFrame) source;
 };
@@ -3798,7 +3798,7 @@ The lifetime of such a {{GPUExternalTexture}} object is implicitly tied to the
 lifetime of the source {{VideoFrame}} object.
 When the {{VideoFrame}} is [=Close VideoFrame|closed=]
 (e.g. via {{VideoFrame/close()}} or
-[[videoframe-transfer-serialization#|transferring the VideoFrame]]),
+[[#videoframe-transfer-serialization|transferring the VideoFrame]]),
 the {{GPUExternalTexture}} is *destroyed*, so no further operations
 using it can be issued.
 

--- a/index.src.html
+++ b/index.src.html
@@ -101,6 +101,14 @@ spec: webrtc-svc; urlPrefix: https://w3c.github.io/webrtc-svc/
 
 spec: visibility-state; urlPrefix: https://www.w3.org/TR/page-visibility/#
     type: enum-value; text: hidden; url: dom-visibilitystate-hidden
+
+spec: webgpu; urlPrefix: https://www.w3.org/TR/webgpu/#
+    type: interface; text: GPUExternalTexture; url: gpuexternaltexture
+    type: dictionary; text: GPUExternalTextureDescriptor; url: dictdef-gpuexternaltexturedescriptor
+    for: GPUExternalTextureDescriptor;
+        type: dict-member; text: source; url: dom-gpuexternaltexturedescriptor-source
+    for: GPUDevice;
+        type: method; text: importExternalTexture(); url: dom-gpudevice-importexternaltexture
 </pre>
 
 <pre class='biblio'>
@@ -3771,6 +3779,26 @@ conversion is explicitly disabled.
 Color space conversion during {{ImageBitmap}} construction is controlled by
 {{ImageBitmapOptions}} {{ImageBitmapOptions/colorSpaceConversion}}. Setting this
 value to "none" disables color space conversion.
+
+### WebGPU ### {#videoframe-webgpu}
+
+WebCodecs extends [[WebGPU]] to allow importing {{VideoFrame}} objects via
+{{GPUDevice/importExternalTexture()}}, producing opaque {{GPUExternalTexture}}
+objects, which can be read from WebGPU shaders.
+The definition of the {{GPUExternalTextureDescriptor/source}} member of
+{{GPUExternalTextureDescriptor}} is modified to allow {{VideoFrame}}:
+
+<xmp>
+partial dictionary GPUExternalTextureDescriptor {
+    required (HTMLVideoElement or VideoFrame) source;
+};
+</xmp>
+
+The lifetime of such a {{GPUExternalTexture}} object is implicitly tied to the
+lifetime of the source {{VideoFrame}} object.
+When the {{VideoFrame}} is [=Close VideoFrame|closed=] (implicitly or
+explicitly), the {{GPUExternalTexture}} is *destroyed*, so no further operations
+using it can be issued.
 
 VideoFrame CopyTo() Options {#videoframe-copyto-options}
 ------------------------------------------------------------

--- a/index.src.html
+++ b/index.src.html
@@ -3796,8 +3796,10 @@ partial dictionary GPUExternalTextureDescriptor {
 
 The lifetime of such a {{GPUExternalTexture}} object is implicitly tied to the
 lifetime of the source {{VideoFrame}} object.
-When the {{VideoFrame}} is [=Close VideoFrame|closed=] (implicitly or
-explicitly), the {{GPUExternalTexture}} is *destroyed*, so no further operations
+When the {{VideoFrame}} is [=Close VideoFrame|closed=]
+(e.g. via {{VideoFrame/close()}} or
+[[videoframe-transfer-serialization#|transferring the VideoFrame]]),
+the {{GPUExternalTexture}} is *destroyed*, so no further operations
 using it can be issued.
 
 VideoFrame CopyTo() Options {#videoframe-copyto-options}


### PR DESCRIPTION
The WebGPU community group is so far unable to reach consensus on adding support for WebCodecs interop, because WebCodecs is not agreed upon by the community group members. It has been tentatively proposed to define WebGPU-WebCodecs interop in WebCodecs instead.

Draft for discussion.

Issue: gpuweb/gpuweb#2124


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kainino0x/webcodecs/pull/412.html" title="Last updated on Dec 9, 2021, 3:16 AM UTC (690d53b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/412/ff5738b...kainino0x:690d53b.html" title="Last updated on Dec 9, 2021, 3:16 AM UTC (690d53b)">Diff</a>