### PR TITLE
Compare Document.hidden with a boolean

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -29,6 +29,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 
 <pre class=link-defaults>
 spec:webidl; type:interface; text:Promise
+spec:html; type:attribute; text:hidden
 </pre>
 
 <pre class='anchors'>
@@ -98,9 +99,6 @@ spec: css-images-3; urlPrefix: https://www.w3.org/TR/css-images-3/
 
 spec: webrtc-svc; urlPrefix: https://w3c.github.io/webrtc-svc/
     type: dfn; text: scalability mode identifier; url:#scalabilitymodes*
-
-spec: visibility-state; urlPrefix: https://www.w3.org/TR/page-visibility/#
-    type: enum-value; text: hidden; url: dom-visibilitystate-hidden
 </pre>
 
 <pre class='biblio'>
@@ -5105,7 +5103,7 @@ not meet the definition of an [=active codec=].
 
 A <dfn lt="background codec|background">background codec</dfn> is a codec whose
 {{ownerDocument}} (or [=owner set=]'s {{Document}}, for codecs in workers) has a
-{{Document/hidden}} attribute equal to {{hidden|"hidden"}}.
+{{Document/hidden}} attribute equal to `true`.
 
 A User Agent MUST only [=reclaim a codec=] that is either an
 [=inactive codec=], a [=background codec=], or both. A User Agent MUST NOT


### PR DESCRIPTION
The spec confused the `hidden` attribute with the `visibilityState` attribute. The latter is a string that can take the value `"hidden"`. The [former is a boolean](https://html.spec.whatwg.org/multipage/interaction.html#dom-document-hidden) that is true when `visibilityState` equals `"hidden"`.

This update fixes that and drops the now useless reference to the Page Visibility spec (now integrated in HTML).

(triggered by @kainino0x's comment in https://github.com/w3c/webcodecs/pull/412#issuecomment-989469534)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webcodecs/pull/419.html" title="Last updated on Dec 9, 2021, 11:07 AM UTC (61fc705)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/419/8c5301a...tidoust:61fc705.html" title="Last updated on Dec 9, 2021, 11:07 AM UTC (61fc705)">Diff</a>