### PR TITLE
Replace channelCount with numberOfChannels throughout

### DIFF
--- a/aac_codec_registration.src.html
+++ b/aac_codec_registration.src.html
@@ -37,7 +37,7 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: attribute
         text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
         text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
-        text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
+        text: AudioDecoderConfig.numberOfChannels; url: dom-audiodecoderconfig-numberofchannels
     type: dfn
         for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
         for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
@@ -94,7 +94,7 @@ and the bitstream is assumed to be in {{AacBitstreamFormat/aac}}.
 If the {{AudioDecoderConfig.description}} is not present, the bitstream is
 assumed to be in {{AacBitstreamFormat/adts}} format.
 
-The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.channelCount}}
+The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.numberOfChannels}}
 members are ignored.
 
 EncodedAudioChunk type {#encodedaudiochunk-type}

--- a/alaw_codec_registration.src.html
+++ b/alaw_codec_registration.src.html
@@ -36,8 +36,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: attribute
         text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
-        text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
-        text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
     type: dfn
         for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
         for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot

--- a/flac_codec_registration.src.html
+++ b/flac_codec_registration.src.html
@@ -37,7 +37,7 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: attribute
         text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
         text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
-        text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
+        text: AudioDecoderConfig.numberOfChannels; url: dom-audiodecoderconfig-numberofchannels
     type: dfn
         for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
         for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
@@ -78,7 +78,7 @@ AudioDecoderConfig description {#audiodecoderconfig-description}
 - A `METADATA_BLOCK` of type `STEAMINFO` as described in [[FLAC]]
 - Optionaly other `METADATA_BLOCK`, that are not used by the specification
 
-The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.channelCount}}
+The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.numberOfChannels}}
 members are overridden by what the decoder finds in the
 {{AudioDecoderConfig.description}}.
 

--- a/mp3_codec_registration.src.html
+++ b/mp3_codec_registration.src.html
@@ -36,7 +36,7 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: attribute
         text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
         text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
-        text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
+        text: AudioDecoderConfig.numberOfChannels; url: dom-audiodecoderconfig-numberofchannels
     type: dfn
         for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
         for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
@@ -80,7 +80,7 @@ AudioDecoderConfig description {#audiodecoderconfig-description}
 
 {{AudioDecoderConfig.description}} is not used for this codec.
 
-The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.channelCount}}
+The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.numberOfChannels}}
 members are ignored.
 
 

--- a/pcm_codec_registration.src.html
+++ b/pcm_codec_registration.src.html
@@ -40,8 +40,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: attribute
         text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
-        text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
-        text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
     type: dfn
         for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
         for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot

--- a/ulaw_codec_registration.src.html
+++ b/ulaw_codec_registration.src.html
@@ -36,8 +36,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: attribute
         text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
-        text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
-        text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
     type: dfn
         for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
         for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot

--- a/vorbis_codec_registration.src.html
+++ b/vorbis_codec_registration.src.html
@@ -37,7 +37,7 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: attribute
         text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
         text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
-        text: AudioDecoderConfig.channelCount; url: dom-audiodecoderconfig-channelcount
+        text: AudioDecoderConfig.numberOfChannels; url: dom-audiodecoderconfig-numberofchannels
     type: dfn
         for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
         for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
@@ -85,7 +85,7 @@ three Vorbis header packets, respectively the identification header, the comment
 header, and the setup header, in this order, as described in section 4.2 of
 [[VORBIS]].
 
-The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.channelCount}}
+The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.numberOfChannels}}
 members are overridden by what the decoder finds in the identification header.
 
 NOTE: The comments header content is not used by [[WEBCODECS]].


### PR DESCRIPTION
The `channelCount` property does not exist on `AudioDecoderConfig`. It should rather be `numberOfChannels`.

This update drops updates the invalid references and drops those that are not used in the specs.