### PR TITLE
Fix reference to PCM codec registration

### DIFF
--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -151,7 +151,7 @@ Audio Codec Registry {#audio-codec-registry}
     <td>Linear PCM</td>
     <td>[Linear PCM WebCodecs
       Registration](https://www.w3.org/TR/webcodecs-pcm-codec-registration/)
-    [[WEBCODECS-ALAW-CODEC-REGISTRATION]]</td>
+    [[WEBCODECS-PCM-CODEC-REGISTRATION]]</td>
   </tr>
 </table>
 


### PR DESCRIPTION
This PR fixes the Linear PCM entry, which currently links to the A-Law entry in the References section.