### PR TITLE
Describe that WG consensus is needed to add registry entries

### DIFF
--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -85,9 +85,9 @@ Registration Entry Requirements {#registration-entry-requirements}
 4. Candidate entries must be announced by filing an issue in the
     [WebCodecs GitHub issue tracker](https://github.com/w3c/webcodecs/issues/)
     so they can be discussed and evaluated for compliance before being added to
-    the registry. If registry editors reach consensus to accept the candidate,
-    a pull request should be drafted (either by editors or by the party
-    requesting the candidate registration) to register the candidate. The
+    the registry. If the Media Working Group reaches consensus to accept the
+    candidate, a pull request should be drafted (either by editors or by the
+    party requesting the candidate registration) to register the candidate. The
     registry editors will review and merge the pull request.
 
 Audio Codec Registry {#audio-codec-registry}


### PR DESCRIPTION
This is to match expected practice in the WG, and the process we're following for reviewing the proposed H.263 registration.