### PR TITLE
[OPUS registration] Fix typo

### DIFF
--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -117,7 +117,7 @@ partial dictionary AudioEncoderConfig {
 </pre>
 
 <dl>
-  <dt><dfn dict-member for=AudioEncoderConfig>opus</dfn></dt>b
+  <dt><dfn dict-member for=AudioEncoderConfig>opus</dfn></dt>
   <dd>
     Contains codec specific configuration options for the Opus codec.
   </dd>


### PR DESCRIPTION
Note the typo now also triggers HTML markup validation errors (Bikeshed used to fix things automatically but no longer does)