### PR TITLE
`[EnforceRange] required` is out of spec

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1674,8 +1674,8 @@ AudioDecoderConfig{#audio-decoder-config}
 <xmp class='idl'>
 dictionary AudioDecoderConfig {
   required DOMString codec;
-  [EnforceRange] required unsigned long sampleRate;
-  [EnforceRange] required unsigned long numberOfChannels;
+  required [EnforceRange] unsigned long sampleRate;
+  required [EnforceRange] unsigned long numberOfChannels;
   BufferSource description;
 };
 </xmp>
@@ -1850,8 +1850,8 @@ VideoEncoderConfig{#video-encoder-config}
 <xmp class='idl'>
 dictionary VideoEncoderConfig {
   required DOMString codec;
-  [EnforceRange] required unsigned long width;
-  [EnforceRange] required unsigned long height;
+  required [EnforceRange] unsigned long width;
+  required [EnforceRange] unsigned long height;
   [EnforceRange] unsigned long displayWidth;
   [EnforceRange] unsigned long displayHeight;
   [EnforceRange] unsigned long long bitrate;
@@ -2207,7 +2207,7 @@ interface EncodedAudioChunk {
 
 dictionary EncodedAudioChunkInit {
   required EncodedAudioChunkType type;
-  [EnforceRange] required long long timestamp;    // microseconds
+  required [EnforceRange] long long timestamp;    // microseconds
   [EnforceRange] unsigned long long duration;     // microseconds
   required BufferSource data;
 };
@@ -2279,7 +2279,7 @@ interface EncodedVideoChunk {
 
 dictionary EncodedVideoChunkInit {
   required EncodedVideoChunkType type;
-  [EnforceRange] required long long timestamp;        // microseconds
+  required [EnforceRange] long long timestamp;        // microseconds
   [EnforceRange] unsigned long long duration;         // microseconds
   required BufferSource data;
 };
@@ -2427,9 +2427,9 @@ interface AudioData {
 dictionary AudioDataInit {
   required AudioSampleFormat format;
   required float sampleRate;
-  [EnforceRange] required unsigned long numberOfFrames;
-  [EnforceRange] required unsigned long numberOfChannels;
-  [EnforceRange] required long long timestamp;  // microseconds
+  required [EnforceRange] unsigned long numberOfFrames;
+  required [EnforceRange] unsigned long numberOfChannels;
+  required [EnforceRange] long long timestamp;  // microseconds
   required BufferSource data;
 };
 </xmp>
@@ -2708,7 +2708,7 @@ Note: It's expected that {{AudioDataInit}}'s {{AudioDataInit/data}}'s memory
 
 <xmp class='idl'>
 dictionary AudioDataCopyToOptions {
-  [EnforceRange] required unsigned long planeIndex;
+  required [EnforceRange] unsigned long planeIndex;
   [EnforceRange] unsigned long frameOffset = 0;
   [EnforceRange] unsigned long frameCount;
   AudioSampleFormat format;
@@ -3858,8 +3858,8 @@ planes as decided by the User Agent.
 
 <xmp class='idl'>
 dictionary PlaneLayout {
-  [EnforceRange] required unsigned long offset;
-  [EnforceRange] required unsigned long stride;
+  required [EnforceRange] unsigned long offset;
+  required [EnforceRange] unsigned long stride;
 };
 </xmp>
 


### PR DESCRIPTION
By the spec here [1], it seems `[EnforceRange] required *` should be
replaced by `required [EnforceRange] *`.

[1] https://webidl.spec.whatwg.org/#extended-attributes-applicable-to-types


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ChunMinChang/webcodecs/pull/488.html" title="Last updated on Apr 28, 2022, 11:56 PM UTC (4baed43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/488/34e21cb...ChunMinChang:4baed43.html" title="Last updated on Apr 28, 2022, 11:56 PM UTC (4baed43)">Diff</a>