### PR TITLE
Remove ImageTrack.onchange event.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -5023,11 +5023,10 @@ ImageTrack Interface {#imagetrack-interface}
 <pre class='idl'>
 <xmp>
 [Exposed=(Window,DedicatedWorker)]
-interface ImageTrack : EventTarget {
+interface ImageTrack {
   readonly attribute boolean animated;
   readonly attribute unsigned long frameCount;
   readonly attribute unrestricted float repetitionCount;
-  attribute EventHandler onchange;
   attribute boolean selected;
 };
 </xmp>
@@ -5072,10 +5071,6 @@ interface ImageTrack : EventTarget {
 :: The {{ImageTrack/repetitionCount}} getter steps are to return the value of
     {{ImageTrack/[[repetition count]]}}.
 
-: <dfn attribute for=ImageTrack>onchange</dfn>
-:: An [=event handler IDL attribute=] whose [=event handler event type=] is
-    {{ImageTrack/change}}.
-
 : <dfn attribute for=ImageTrack>selected</dfn>
 :: The {{ImageTrack/selected}} getter steps are to return the value of
     {{ImageTrack/[[selected]]}}.
@@ -5113,12 +5108,6 @@ interface ImageTrack : EventTarget {
         {{ImageDecoder/[[internal selected track index]]}}.
     2. Remove all entries from
         {{ImageDecoder/[[progressive frame generations]]}}.
-
-
-### Event Summary ### {#imagetracklist-eventsummary}
-
-: <dfn event for=ImageTrack>change</dfn>
-:: Fired at the {{ImageTrack}} when the {{ImageTrack/frameCount}} is altered.
 
 Resource Reclamation{#resource-reclamation}
 ==============================================


### PR DESCRIPTION
We decided not to do this, but forgot to remove it from the spec. The fact that
decode() calls stall until the next frame is available and the availability of the
`completed` promise make it largely unnecessary.

Clients which don't want to wait for for `completed` can instead handle a
RangeError exception during decode() if no more frames remain. While not
ideal it's inefficient to implement something like onchange since common
formats like GIF would require us to attempt decode in order to update the
frame count.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 6, 2022, 11:07 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebcodecs%2F99fe3034e5feed0e7708510fe96670d5112093f7%2Findex.src.html&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
WARNING: IGNORED LEGACY IDL LINE: 5 - ","
WARNING: IGNORED LEGACY IDL LINE: 4 - ","
WARNING: IGNORED LEGACY IDL LINE: 22 - ","
WARNING: IGNORED LEGACY IDL LINE: 10 - ","
WARNING: IGNORED LEGACY IDL LINE: 20 - ","
WARNING: IGNORED LEGACY IDL LINE: 6 - ","
FATAL ERROR: Obsolete biblio ref: [rfc7231] is replaced by [rfc9110]. Either update the reference, or use [rfc7231 obsolete] if this is an intentionally-obsolete reference.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webcodecs%23497.)._
</details>
