### PR TITLE
Align event phrasing with DOM spec

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4682,7 +4682,7 @@ interface ImageDecoder {
                 {{ImageTrackList/[[track list]]}}.
             2. Assign `update.frameCount` to |updateTrack|'s
                 {{ImageTrack/[[frame count]]}}.
-            3. Fire a simple event named {{ImageTrack/change}} at the
+            3. [=Fire an event=] named {{ImageTrack/change}} at the
                 {{ImageDecoder/tracks}} object.
 
 : <dfn for=ImageDecoder>Decode Complete Frame</dfn> (with |frameIndex| and


### PR DESCRIPTION
see https://dom.spec.whatwg.org/#firing-events-example


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 8, 2022, 1:00 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdontcallmedom%2Fwebcodecs%2F961b335cd5354953824ff8456c72369f9a712d84%2Findex.src.html&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
WARNING: IGNORED LEGACY IDL LINE: 5 - ","
WARNING: IGNORED LEGACY IDL LINE: 4 - ","
WARNING: IGNORED LEGACY IDL LINE: 22 - ","
WARNING: IGNORED LEGACY IDL LINE: 10 - ","
WARNING: IGNORED LEGACY IDL LINE: 20 - ","
WARNING: IGNORED LEGACY IDL LINE: 6 - ","
FATAL ERROR: Obsolete biblio ref: [rfc7231] is replaced by [rfc9110]. Either update the reference, or use [rfc7231 obsolete] if this is an intentionally-obsolete reference.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webcodecs%23498.)._
</details>
