### PR TITLE
Add AudioData copy constructor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifdef WEBCODECS_IGNORE_WARNINGS
 	bikeshed -f spec $< $@
 else
 	@ echo "Building $@"
-	bikeshed --die-on=warning spec $< $@
+	bikeshed -f spec $< $@
 endif
 else
 	@ echo "Building $@ remotely"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifdef WEBCODECS_IGNORE_WARNINGS
 	bikeshed -f spec $< $@
 else
 	@ echo "Building $@"
-	bikeshed -f spec $< $@
+	bikeshed --die-on=warning spec $< $@
 endif
 else
 	@ echo "Building $@ remotely"

--- a/index.src.html
+++ b/index.src.html
@@ -2494,18 +2494,19 @@ dictionary AudioDataCopyInit {
     return |source|.{{AudioData/clone()}}.
 3. Let |copy| be a new {{AudioData}} object, initialized as follows:
     1. Assign `false` to {{platform object/[[Detached]]}}.
-    2. Assign |source|.{{AudioDataInit/format}} to
+    2. Assign |source|.{{AudioData/[[format]]}} to
         {{AudioData/[[format]]}}.
-    3. Assign |source|.{{AudioDataInit/sampleRate}} to
+    3. Assign |source|.{{AudioData/[[sample rate]]}} to
         {{AudioData/[[sample rate]]}}.
-    4. Assign |source|.{{AudioDataInit/numberOfFrames}} to
+    4. Assign |source|.{{AudioData/[[number of frames]]}} to
         {{AudioData/[[number of frames]]}}.
-    5. Assign |source|.{{AudioDataInit/numberOfChannels}} to
+    5. Assign |source|.{{AudioData/[[number of channels]]}} to
         {{AudioData/[[number of channels]]}}.
     6. Assign |init|.{{AudioDataCopyInit/timestamp}} to
         {{AudioData/[[timestamp]]}}.
-    7. Let |resource| be a [=media resource=] containing a copy of
-        |source|.{{AudioDataInit/data}}.
+    7. Let |resource| be a [=media resource=] containing a copy of the
+        [=media resource=] referenced by
+        |source|.{{AudioData/[[resource reference]]}}.
     8. Let |resourceReference| be a reference to |resource|.
     9. Assign |resourceReference| to {{AudioData/[[resource reference]]}}.
 4. Return |copy|.

--- a/index.src.html
+++ b/index.src.html
@@ -2410,6 +2410,7 @@ AudioData Interface {#audiodata-interface}
 [Exposed=(Window,DedicatedWorker), Serializable, Transferable]
 interface AudioData {
   constructor(AudioDataInit init);
+  constructor(AudioData source, AudioDataCopyInit init);
 
   readonly attribute AudioSampleFormat? format;
   readonly attribute float sampleRate;
@@ -2431,6 +2432,10 @@ dictionary AudioDataInit {
   [EnforceRange] required unsigned long numberOfChannels;
   [EnforceRange] required long long timestamp;  // microseconds
   required BufferSource data;
+};
+
+dictionary AudioDataCopyInit {
+  [EnforceRange] required long long timestamp;  // microseconds
 };
 </xmp>
 
@@ -2462,7 +2467,7 @@ dictionary AudioDataInit {
   AudioData(init)
 </dfn>
 1. If |init| is not a [=valid AudioDataInit=], throw a {{TypeError}}.
-2. Let |frame| be a new {{AudioData}} object, initialized as follows:
+2. Let |audio| be a new {{AudioData}} object, initialized as follows:
     1. Assign `false` to {{platform object/[[Detached]]}}.
     2. Assign |init|.{{AudioDataInit/format}} to
         {{AudioData/[[format]]}}.
@@ -2478,7 +2483,30 @@ dictionary AudioDataInit {
         |init|.{{AudioDataInit/data}}.
     8. Let |resourceReference| be a reference to |resource|.
     9. Assign |resourceReference| to {{AudioData/[[resource reference]]}}.
-3. Return |frame|.
+3. Return |audio|.
+
+<dfn constructor for=AudioData title="AudioData(source, init)">
+  AudioData(source, init)
+</dfn>
+1. If |source|.{{platform object/[[Detached]]}} is `true`, throw an
+    {{InvalidStateError}} {{DOMException}}.
+2. Let |copy| be a new {{AudioData}} object, initialized as follows:
+    1. Assign `false` to {{platform object/[[Detached]]}}.
+    2. Assign |source|.{{AudioDataInit/format}} to
+        {{AudioData/[[format]]}}.
+    3. Assign |source|.{{AudioDataInit/sampleRate}} to
+        {{AudioData/[[sample rate]]}}.
+    4. Assign |source|.{{AudioDataInit/numberOfFrames}} to
+        {{AudioData/[[number of frames]]}}.
+    5. Assign |source|.{{AudioDataInit/numberOfChannels}} to
+        {{AudioData/[[number of channels]]}}.
+    6. Assign |init|.{{AudioDataInit/timestamp}} to
+        {{AudioData/[[timestamp]]}}.
+    7. Let |resource| be a [=media resource=] containing a copy of
+        |source|.{{AudioDataInit/data}}.
+    8. Let |resourceReference| be a reference to |resource|.
+    9. Assign |resourceReference| to {{AudioData/[[resource reference]]}}.
+3. Return |copy|.
 
 ### Attributes ###{#audiodata-attributes}
 

--- a/index.src.html
+++ b/index.src.html
@@ -2410,7 +2410,7 @@ AudioData Interface {#audiodata-interface}
 [Exposed=(Window,DedicatedWorker), Serializable, Transferable]
 interface AudioData {
   constructor(AudioDataInit init);
-  constructor(AudioData source, AudioDataCopyInit init);
+  constructor(AudioData source, optional AudioDataCopyInit init = {});
 
   readonly attribute AudioSampleFormat? format;
   readonly attribute float sampleRate;
@@ -2435,7 +2435,7 @@ dictionary AudioDataInit {
 };
 
 dictionary AudioDataCopyInit {
-  [EnforceRange] required long long timestamp;  // microseconds
+  [EnforceRange] long long timestamp;  // microseconds
 };
 </xmp>
 
@@ -2490,7 +2490,9 @@ dictionary AudioDataCopyInit {
 </dfn>
 1. If |source|.{{platform object/[[Detached]]}} is `true`, throw an
     {{InvalidStateError}} {{DOMException}}.
-2. Let |copy| be a new {{AudioData}} object, initialized as follows:
+2. If |init|.{{AudioDataCopyInit/timestamp}} does not [=map/exist=],
+    return |source|.{{AudioData/clone()}}.
+3. Let |copy| be a new {{AudioData}} object, initialized as follows:
     1. Assign `false` to {{platform object/[[Detached]]}}.
     2. Assign |source|.{{AudioDataInit/format}} to
         {{AudioData/[[format]]}}.
@@ -2500,13 +2502,13 @@ dictionary AudioDataCopyInit {
         {{AudioData/[[number of frames]]}}.
     5. Assign |source|.{{AudioDataInit/numberOfChannels}} to
         {{AudioData/[[number of channels]]}}.
-    6. Assign |init|.{{AudioDataInit/timestamp}} to
+    6. Assign |init|.{{AudioDataCopyInit/timestamp}} to
         {{AudioData/[[timestamp]]}}.
     7. Let |resource| be a [=media resource=] containing a copy of
         |source|.{{AudioDataInit/data}}.
     8. Let |resourceReference| be a reference to |resource|.
     9. Assign |resourceReference| to {{AudioData/[[resource reference]]}}.
-3. Return |copy|.
+4. Return |copy|.
 
 ### Attributes ###{#audiodata-attributes}
 


### PR DESCRIPTION
Addresses #505

Some notes:
- The VideoFrame constructor is of the form
```
  constructor(CanvasImageSourceimage, optional VideoFrameInit init = {})
```

Which allows copying a frame by calling `new VideoFrame(oldFrame)`. This PR mirrors the same behavior for AudioData.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jun 30, 2022, 9:50 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Ftguilbert-google%2Fwebcodecs%2F1a2508a73dc2ed7a652bf90089bc0697642bfca2%2Findex.src.html&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
WARNING: IGNORED LEGACY IDL LINE: 5 - ","
WARNING: IGNORED LEGACY IDL LINE: 4 - ","
WARNING: IGNORED LEGACY IDL LINE: 22 - ","
WARNING: IGNORED LEGACY IDL LINE: 10 - ","
WARNING: IGNORED LEGACY IDL LINE: 20 - ","
WARNING: IGNORED LEGACY IDL LINE: 6 - ","
FATAL ERROR: Obsolete biblio ref: [rfc7231] is replaced by [rfc9110]. Either update the reference, or use [rfc7231 obsolete] if this is an intentionally-obsolete reference.
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webcodecs%23506.)._
</details>
