### PR TITLE
Revert "Fix the problem that getAvccBox cannot get the value when the first track of the video is not AVC"

### DIFF
--- a/samples/mp4-decode/mp4_demuxer.js
+++ b/samples/mp4-decode/mp4_demuxer.js
@@ -52,8 +52,7 @@ class MP4Source {
 
   getAvccBox() {
     // TODO: make sure this is coming from the right track.
-    const traks = this.file.moov.traks.filter(trak => trak.mdia.minf.stbl.stsd.entries[0].avcC);
-    return traks[0].mdia.minf.stbl.stsd.entries[0].avcC;
+    return this.file.moov.traks[0].mdia.minf.stbl.stsd.entries[0].avcC
   }
 
   start(track, onChunk) {


### PR DESCRIPTION
Reverts w3c/webcodecs#489

The original commit broke the sample

'Error handling response: TypeError: Cannot read properties of undefined (reading 'filter')'
