### PR TITLE
Revert "Revert "Fix the problem that getAvccBox cannot get the value when the first track of the video is not AVC""

### DIFF
--- a/samples/mp4-decode/mp4_demuxer.js
+++ b/samples/mp4-decode/mp4_demuxer.js
@@ -52,7 +52,8 @@ class MP4Source {
 
   getAvccBox() {
     // TODO: make sure this is coming from the right track.
-    return this.file.moov.traks[0].mdia.minf.stbl.stsd.entries[0].avcC
+    const traks = this.file.moov.traks.filter(trak => trak.mdia.minf.stbl.stsd.entries[0].avcC);
+    return traks[0].mdia.minf.stbl.stsd.entries[0].avcC;
   }
 
   start(track, onChunk) {


### PR DESCRIPTION
Reverts w3c/webcodecs#524

I thought the initial commit broke the sample, but it turns out the error was from a plugin script that I had installed. In my local testing I've verified that the sample works fine with the initial commit applied, so lets revert back to that. 