### PR TITLE
Codec registry: escape "*" in codec strings

### DIFF
--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -112,7 +112,7 @@ Audio Codec Registry {#audio-codec-registry}
     [[WEBCODECS-MP3-CODEC-REGISTRATION]]</td>
   </tr>
   <tr>
-    <td>mp4a.*</td>
+    <td>mp4a.\*</td>
     <td>AAC</td>
     <td>[AAC WebCodecs
       Registration](https://www.w3.org/TR/webcodecs-aac-codec-registration/)
@@ -147,7 +147,7 @@ Audio Codec Registry {#audio-codec-registry}
     [[WEBCODECS-ALAW-CODEC-REGISTRATION]]</td>
   </tr>
   <tr>
-    <td>pcm-*</td>
+    <td>pcm-\*</td>
     <td>Linear PCM</td>
     <td>[Linear PCM WebCodecs
       Registration](https://www.w3.org/TR/webcodecs-pcm-codec-registration/)
@@ -165,17 +165,17 @@ Video Codec Registry {#video-codec-registry}
     <td>**specification**</td>
   </tr>
   <tr>
-    <td>av01.*</td>
+    <td>av01.\*</td>
     <td>AV1</td>
     <td>[AV1 codec registration](https://www.w3.org/TR/webcodecs-av1-codec-registration/) [[WEBCODECS-AV1-CODEC-REGISTRATION]]</td>
   </tr>
   <tr>
-    <td>avc1.*, avc3.*</td>
+    <td>avc1.\*, avc3.\*</td>
     <td>AVC / H.264</td>
     <td>[AVC (H.264) WebCodecs Registration](https://www.w3.org/TR/webcodecs-avc-codec-registration/) [[WEBCODECS-AVC-CODEC-REGISTRATION]]</td>
   </tr>
   <tr>
-    <td>hev1.*, hvc1.*</td>
+    <td>hev1.\*, hvc1.\*</td>
     <td>HEVC / H.265</td>
     <td>[HEVC (H.265) WebCodecs Registration](https://www.w3.org/TR/webcodecs-hevc-codec-registration/) [[WEBCODECS-HEVC-CODEC-REGISTRATION]]</td>
   </tr>
@@ -185,7 +185,7 @@ Video Codec Registry {#video-codec-registry}
     <td>[VP8 codec registration](https://www.w3.org/TR/webcodecs-vp8-codec-registration/) [[WEBCODECS-VP8-CODEC-REGISTRATION]]</td>
   </tr>
   <tr>
-    <td>vp09.*</td>
+    <td>vp09.\*</td>
     <td>VP9</td>
     <td>[VP9 codec registration](https://www.w3.org/TR/webcodecs-vp9-codec-registration/) [[WEBCODECS-VP9-CODEC-REGISTRATION]]</td>
   </tr>


### PR DESCRIPTION
As the spec uses Markdown, some of the `*` characters were interpreted by Bikeshed as a request to turn the string in italics, whereas we actually want to render the asterisk characters. For instance, `hev1.*, hvc1.*` was rendered as `hev1. <em>, hvc1.<em>`.

This update escapes the asterisk character in codec strings.