### PR TITLE
Fix visible rect comparison to use strict equality to allow for visible rect of the same size as coded size

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3683,10 +3683,10 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
             {{VideoFrameInit/visibleRect}}.{{DOMRectInit/height}} == `0` return
             `false`.
         5. If {{VideoFrameInit/visibleRect}}.{{DOMRectInit/y}} +
-            {{VideoFrameInit/visibleRect}}.{{DOMRectInit/height}} >=
+            {{VideoFrameInit/visibleRect}}.{{DOMRectInit/height}} >
             |codedHeight|, return `false`.
         6. If {{VideoFrameInit/visibleRect}}.{{DOMRectInit/x}} +
-            {{VideoFrameInit/visibleRect}}.{{DOMRectInit/width}} >=
+            {{VideoFrameInit/visibleRect}}.{{DOMRectInit/width}} >
             |codedWidth|, return `false`.
     2. If |codedWidth| = 0 or |codedHeight| = 0,return `false`.
     3. If only one of {{VideoFrameInit/displayWidth}} or
@@ -3702,10 +3702,10 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
     2. If any attribute of {{VideoFrameBufferInit/visibleRect}} is negative or
         not finite, return `false`.
     3. If {{VideoFrameBufferInit/visibleRect}}.{{DOMRectInit/y}} +
-        {{VideoFrameBufferInit/visibleRect}}.{{DOMRectInit/height}} >=
+        {{VideoFrameBufferInit/visibleRect}}.{{DOMRectInit/height}} >
         {{VideoFrameBufferInit/codedHeight}}, return `false`.
     4. If {{VideoFrameBufferInit/visibleRect}}.{{DOMRectInit/x}} +
-        {{VideoFrameBufferInit/visibleRect}}.{{DOMRectInit/width}} >=
+        {{VideoFrameBufferInit/visibleRect}}.{{DOMRectInit/width}} >
         {{VideoFrameBufferInit/codedWidth}}, return `false`.
     5. If only one of {{VideoFrameBufferInit/displayWidth}} or
         {{VideoFrameBufferInit/displayHeight}} [=map/exists=], return `false`.


### PR DESCRIPTION
This fixes #515.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/541.html" title="Last updated on Aug 29, 2022, 1:34 PM UTC (24a7d8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/541/3dfd474...24a7d8c.html" title="Last updated on Aug 29, 2022, 1:34 PM UTC (24a7d8c)">Diff</a>