### PR TITLE
Add frameDuration attribute to OpusEncoderConfig

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2073,7 +2073,10 @@ To check if an {{AudioEncoderConfig}} is a <dfn>valid AudioEncoderConfig</dfn>,
 run these steps:
 1. If {{AudioEncoderConfig/codec}} is not a <a>valid codec string</a>, return
     `false`.
-2. Return `true`.
+2. If the current codec's registry defines a codec-specific additional configuration
+    validation steps, run the algorithm defined in the registry. If the return
+    value is `false`, return it.
+3. Return `true`.
 
 <dl>
   <dt><dfn dict-member for=AudioEncoderConfig>codec</dfn></dt>

--- a/index.src.html
+++ b/index.src.html
@@ -2073,9 +2073,9 @@ To check if an {{AudioEncoderConfig}} is a <dfn>valid AudioEncoderConfig</dfn>,
 run these steps:
 1. If {{AudioEncoderConfig/codec}} is not a <a>valid codec string</a>, return
     `false`.
-2. If the current codec's registry defines a codec-specific additional configuration
-    validation steps, run the algorithm defined in the registry. If the return
-    value is `false`, return it.
+2. If the {{AudioEncoderConfig}} has a codec-specific extension and the corresponding 
+    registration in the [[WEBCODECS-CODEC-REGISTRY]] defines steps to check whether the
+    the extension is a valid extension, return the result of running those steps.
 3. Return `true`.
 
 <dl>

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -131,6 +131,7 @@ OpusEncoderConfig {#opus-encoder-config}
 <xmp>
 dictionary OpusEncoderConfig {
   OpusBitstreamFormat format = "opus";
+  [EnforceRange] unsigned long frameDuration;
 };
 </xmp>
 </pre>
@@ -140,6 +141,10 @@ dictionary OpusEncoderConfig {
   <dd>
     Configures the format of output {{EncodedAudioChunk}}s. See
     {{OpusBitstreamFormat}}.
+  </dd>
+  <dt><dfn dict-member for=OpusEncoderConfig>frameDuration</dfn></dt>
+  <dd>
+    Configures the frame duration, in milliseconds, of output {{EncodedAudioChunk}}s.
   </dd>
 </dl>
 

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -105,7 +105,7 @@ Opus is always "[=EncodedAudioChunkType/key=]".
 NOTE: Once the initialization has succeeded, any packet can be decoded at any
 time without error, but this might not result in the expected audio output.
 
-AudiEncoderConfig extensions {#audioencoderconfig-extensions}
+AudioEncoderConfig extensions {#audioencoderconfig-extensions}
 =============================================================
 
 <pre class='idl'>
@@ -131,10 +131,16 @@ OpusEncoderConfig {#opus-encoder-config}
 <xmp>
 dictionary OpusEncoderConfig {
   OpusBitstreamFormat format = "opus";
-  [EnforceRange] unsigned long long frameDuration;
+  [EnforceRange] unsigned long frameDuration;
 };
 </xmp>
 </pre>
+
+To check if an {{OpusEncoderConfig}} is a valid OpusEncoderConfig,
+run these steps:
+1. If {{OpusEncoderConfig/frameDuration}} is not a valid ptime value,
+    which is described in section 6.1 of [[RFC6381]], return `false`.
+2. Return `true`.
 
 <dl>
   <dt><dfn dict-member for=OpusEncoderConfig>format</dfn></dt>
@@ -144,7 +150,7 @@ dictionary OpusEncoderConfig {
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>frameDuration</dfn></dt>
   <dd>
-    Configures the frame duration, in microseconds, of output {{EncodedAudioChunk}}s.
+    Configures the frame duration, in milliseconds, of output {{EncodedAudioChunk}}s.
   </dd>
 </dl>
 

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -137,7 +137,7 @@ dictionary OpusEncoderConfig {
 </pre>
 
 To check if an {{OpusEncoderConfig}} is valid, run these steps:
-1. If {{OpusEncoderConfig/frameDuration}} is not a valid ptime value,
+1. If {{OpusEncoderConfig/frameDuration}} is not a valid `ptime` value,
     which is described in Section 6.1 of [[RFC7587]], return `false`.
 2. Return `true`.
 

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -136,10 +136,9 @@ dictionary OpusEncoderConfig {
 </xmp>
 </pre>
 
-To check if an {{OpusEncoderConfig}} is a valid OpusEncoderConfig,
-run these steps:
+To check if an {{OpusEncoderConfig}} is valid, run these steps:
 1. If {{OpusEncoderConfig/frameDuration}} is not a valid ptime value,
-    which is described in section 6.1 of [[RFC6381]], return `false`.
+    which is described in Section 6.1 of [[RFC7587]], return `false`.
 2. Return `true`.
 
 <dl>

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -131,7 +131,7 @@ OpusEncoderConfig {#opus-encoder-config}
 <xmp>
 dictionary OpusEncoderConfig {
   OpusBitstreamFormat format = "opus";
-  [EnforceRange] unsigned long frameDuration;
+  [EnforceRange] unsigned long long frameDuration;
 };
 </xmp>
 </pre>
@@ -144,7 +144,7 @@ dictionary OpusEncoderConfig {
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>frameDuration</dfn></dt>
   <dd>
-    Configures the frame duration, in milliseconds, of output {{EncodedAudioChunk}}s.
+    Configures the frame duration, in microseconds, of output {{EncodedAudioChunk}}s.
   </dd>
 </dl>
 


### PR DESCRIPTION
This fixes #371


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bdrtc/webcodecs/pull/551.html" title="Last updated on Sep 26, 2022, 2:15 AM UTC (67cc867)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/551/1db4c21...bdrtc:67cc867.html" title="Last updated on Sep 26, 2022, 2:15 AM UTC (67cc867)">Diff</a>