### PR TITLE
[Publication job] Add HEVC WebCodecs registration

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -93,6 +93,11 @@ jobs:
             echidna_token: ECHIDNA_TOKEN_ULAW_REGISTRATION
             build_override: |
               status: NOTE-WD
+          - source: hevc_codec_registration.src.html
+            destination: hevc_codec_registration.html
+            echidna_token: ECHIDNA_TOKEN_HEVC_REGISTRATION
+            build_override: |
+              status: NOTE-WD
     steps:
       # See doc at https://github.com/actions/checkout#checkout-v2
       - name: Checkout repository


### PR DESCRIPTION
Add HEVC (H.265) WebCodecs Registration to the auto-publish script so that the specs gets published to the `gh-pages` branch (and to /TR later on when a first draft note will have been published)

This follows from the [outcome of the call for consensus](https://lists.w3.org/Archives/Public/public-media-wg/2022Jul/0008.html) and from #499. I'll request publication of the spec to /TR once this PR has been merged.