### PR TITLE
fix a typo in 8.2.1

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2541,7 +2541,7 @@ enum EncodedVideoChunkType {
 : <dfn attribute for=EncodedVideoChunk>[[internal data]]</dfn>
 :: An array of bytes representing the encoded chunk data.
 : <dfn attribute for=EncodedVideoChunk>\[[type]]</dfn>
-:: The {{EncodedAudioChunkType}} of this {{EncodedVideoChunk}};
+:: The {{EncodedVideoChunkType}} of this {{EncodedVideoChunk}};
 : <dfn attribute for=EncodedVideoChunk>\[[timestamp]]</dfn>
 :: The presentation timestamp, given in microseconds.
 : <dfn attribute for=EncodedVideoChunk>\[[duration]]</dfn>


### PR DESCRIPTION
This fixes #554


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bdrtc/webcodecs/pull/555.html" title="Last updated on Sep 5, 2022, 9:13 AM UTC (613f44a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/555/663a095...bdrtc:613f44a.html" title="Last updated on Sep 5, 2022, 9:13 AM UTC (613f44a)">Diff</a>