### PR TITLE
[WebCodecs VideoFrame metadata registry] Introduce VideoFrame metadata

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -99,8 +99,8 @@ jobs:
             build_override: |
               status: NOTE-WD
           - source: video_frame_metadata_registry.src.html
-            destination: video_frame_metadata_registry..html
-            echidna_token: ECHIDNA_TOKEN_HEVC_REGISTRATION
+            destination: video_frame_metadata_registry.html
+            echidna_token: ECHIDNA_TOKEN_VIDEOFRAMEMETADATA_REGISTRY
             build_override: |
               status: NOTE-WD
     steps:

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -102,7 +102,7 @@ jobs:
             destination: video_frame_metadata_registry.html
             echidna_token: ECHIDNA_TOKEN_VIDEOFRAMEMETADATA_REGISTRY
             build_override: |
-              status: NOTE-WD
+              status: DRY
     steps:
       # See doc at https://github.com/actions/checkout#checkout-v2
       - name: Checkout repository

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -98,6 +98,11 @@ jobs:
             echidna_token: ECHIDNA_TOKEN_HEVC_REGISTRATION
             build_override: |
               status: NOTE-WD
+          - source: video_frame_metadata_registry.src.html
+            destination: video_frame_metadata_registry..html
+            echidna_token: ECHIDNA_TOKEN_HEVC_REGISTRATION
+            build_override: |
+              status: NOTE-WD
     steps:
       # See doc at https://github.com/actions/checkout#checkout-v2
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ out/
 pcm_codec_registration.html
 ulaw_codec_registration.html
 ulaw_codec_registration.html
+video_frame_metadata_registry.html
 vorbis_codec_registration.html
 vp8_codec_registration.html
 vp9_codec_registration.html

--- a/index.src.html
+++ b/index.src.html
@@ -3855,7 +3855,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
         and {{VideoFrame/[[display height]]}}.
     5. Assign `null` to |frame|'s {{VideoFrame/[[duration]]}} and
         {{VideoFrame/[[timestamp]]}}.
-    6. Assign a new {{VideoFrameMetadata}} to |frame|'s {{VideoFrame/[[metadata]]}}.
+    6. Assign a new {{VideoFrameMetadata}} to |frame|.{{VideoFrame/[[metadata]]}}.
 
 : <dfn for=VideoFrame>Parse VideoFrameCopyToOptions</dfn> (with |options|)
 ::  1. Let |defaultRect| be the result of performing the getter steps for

--- a/index.src.html
+++ b/index.src.html
@@ -3185,7 +3185,7 @@ interface VideoFrame {
   readonly attribute long long? timestamp;          // microseconds
   readonly attribute VideoColorSpace colorSpace;
 
-  VideoFrameMetadata getMetadata();
+  VideoFrameMetadata metadata();
 
   unsigned long allocationSize(
       optional VideoFrameCopyToOptions options = {});
@@ -3291,6 +3291,7 @@ dictionary VideoFrameMetadata {
 
 : <dfn attribute for=VideoFrame>\[[metadata]]</dfn>
 :: The {{VideoFrameMetadata}} associated with this frame.
+
 <div class='note'>
 {{VideoFrameMetadata}} is designed to be extended by other specifications.
 Specifications that do extend {{VideoFrameMetadata}} must make sure that
@@ -3646,7 +3647,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
 
     When invoked, run the [=Close VideoFrame=] algorithm with [=this=].
 
-: <dfn method for=VideoFrame>getMetadata()</dfn>
+: <dfn method for=VideoFrame>metadata()</dfn>
 :: Gets the {{VideoFrameMetadata}} associated with this frame.
 
     When invoked, return the result of calling [=Copy VideoFrame metadata=]

--- a/index.src.html
+++ b/index.src.html
@@ -100,9 +100,8 @@ spec: css-images-3; urlPrefix: https://www.w3.org/TR/css-images-3/
 spec: webrtc-svc; urlPrefix: https://w3c.github.io/webrtc-svc/
     type: dfn; text: scalability mode identifier; url:#scalabilitymodes*
 
-spec: webcodecs-videoframemetadata-registry; urlPrefix: https://w3c.github.io/webcodecs/videoframemetadata_registry.html
-    type: dictionary
-        text: VideoFrameMetadata; url: dictdef-videoframemetadata
+spec: webcodecs-video-frame-metadata-registry; urlPrefix: https://w3c.github.io/webcodecs/video-frame-metadata-registry.html
+    type: dictionary; text: VideoFrameMetadata; url: dictdef-videoframemetadata
 
 spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     type: dfn; text: the current Realm; url: #current-realm
@@ -3292,11 +3291,8 @@ dictionary VideoFrameBufferInit {
 
 : <dfn attribute for=VideoFrame>\[[metadata]]</dfn>
 :: The {{VideoFrameMetadata}} associated with this frame.
-
-<div class='note'>
-{{VideoFrameMetadata}} is defined in [[webcodecs-videoframemetadata-registry]].
-By design, all {{VideoFrameMetadata}} properties must be serializable.
-</div>
+     {{VideoFrameMetadata}} is defined in [[webcodecs-video-frame-metadata-registry]].
+     By design, all {{VideoFrameMetadata}} properties are serializable.
 
 ### Constructors ###{#videoframe-constructors}
 
@@ -3336,7 +3332,7 @@ By design, all {{VideoFrameMetadata}} properties must be serializable.
             {{InvalidStateError}} {{DOMException}}.
         2. Let |currentPlaybackFrame| be the {{VideoFrame}} at the [=current
             playback position=].
-        3. If {{VideoFrameInit/metadata}} does not [=map/exists=] in |init|,
+        3. If {{VideoFrameInit/metadata}} does not [=map/exist=] in |init|,
             assign |currentPlaybackFrame|.{{VideoFrame/[[metadata]]}} to it.
         4. Run the [=VideoFrame/Initialize Frame From Other Frame=] algorithm
             with |init|, |frame|, and |currentPlaybackFrame|.

--- a/index.src.html
+++ b/index.src.html
@@ -3293,7 +3293,7 @@ dictionary VideoFrameMetadata {
 :: The {{VideoFrameMetadata}} associated with this frame.
 <div class='note'>
 {{VideoFrameMetadata}} is designed to be extended by other specifications.
-Specifications that do extend {{VideoFrameMetadata}} need to make sure that
+Specifications that do extend {{VideoFrameMetadata}} must make sure that
 added properties are serializable.
 </div>
 
@@ -3335,7 +3335,9 @@ added properties are serializable.
             {{InvalidStateError}} {{DOMException}}.
         2. Let |currentPlaybackFrame| be the {{VideoFrame}} at the [=current
             playback position=].
-        3. Run the [=VideoFrame/Initialize Frame From Other Frame=] algorithm
+        3. If {{VideoFrameInit/metadata}} does not [=map/exists=] in |init|,
+            assign |currentPlaybackFrame|.{{VideoFrame/[[metadata]]}} to it.
+        4. Run the [=VideoFrame/Initialize Frame From Other Frame=] algorithm
             with |init|, |frame|, and |currentPlaybackFrame|.
 
     - {{HTMLCanvasElement}}
@@ -3445,7 +3447,7 @@ added properties are serializable.
         algorithm, with |colorSpace| and {{VideoFrame/[[format]]}}, to
         {{VideoFrame/[[color space]]}}.
     10. Assign the result of calling [=Copy VideoFrame metadata=]
-        with |init|'s {{VideoFrameInit/metadata}} to {{VideoFrame/[[metadata]]}}.
+        with |init|'s {{VideoFrameInit/metadata}} to |frame|.{{VideoFrame/[[metadata]]}}.
 17. Return |frame|.
 
 ### Attributes ###{#videoframe-attributes}
@@ -3774,7 +3776,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
         |frame|.{{VideoFrame/timestamp}}.
     11. Assign |format| to |frame|.{{VideoFrame/[[format]]}}.
     12. Assign the result of calling [=Copy VideoFrame metadata=]
-        with |init|'s {{VideoFrameInit/metadata}} to {{VideoFrame/metadata}}.
+        with |init|'s {{VideoFrameInit/metadata}} to |frame|.{{VideoFrame/[[metadata]]}}.
 
 : <dfn for=VideoFrame>Initialize Frame With Resource and Size</dfn> (with
     |init|,  |frame|, |resource|, |width| and |height|)

--- a/index.src.html
+++ b/index.src.html
@@ -100,6 +100,10 @@ spec: css-images-3; urlPrefix: https://www.w3.org/TR/css-images-3/
 spec: webrtc-svc; urlPrefix: https://w3c.github.io/webrtc-svc/
     type: dfn; text: scalability mode identifier; url:#scalabilitymodes*
 
+spec: webcodecs-videoframemetadata-registry; urlPrefix: https://w3c.github.io/webcodecs/videoframemetadata_registry.html
+    type: dictionary
+        text: VideoFrameMetadata; url: dictdef-videoframemetadata
+
 spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     type: dfn; text: the current Realm; url: #current-realm
 </pre>
@@ -3232,9 +3236,6 @@ dictionary VideoFrameBufferInit {
 
   VideoColorSpaceInit colorSpace;
 };
-
-dictionary VideoFrameMetadata {
-};
 </xmp>
 
 ### Internal Slots ###{#videoframe-internal-slots}
@@ -3293,9 +3294,8 @@ dictionary VideoFrameMetadata {
 :: The {{VideoFrameMetadata}} associated with this frame.
 
 <div class='note'>
-{{VideoFrameMetadata}} is designed to be extended by other specifications.
-Specifications that do extend {{VideoFrameMetadata}} must make sure that
-added properties are serializable.
+{{VideoFrameMetadata}} is defined in [[webcodecs-videoframemetadata-registry]].
+By design, all {{VideoFrameMetadata}} properties must be serializable.
 </div>
 
 ### Constructors ###{#videoframe-constructors}

--- a/index.src.html
+++ b/index.src.html
@@ -114,6 +114,15 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     "title": "Coding-independent code points for video signal type identification",
     "publisher": "ITU",
     "date": "December 2016"
+  },
+  "WEBCODECS-VIDEO-FRAME-METADATA-REGISTRY": {
+    "href": "https://w3c.github.io/webcodecs/video_frame_metadata_registry.html",
+    "title": "WebCodecs VideoFrame Metadata Registry",
+    "publisher": "W3C",
+    "authors": [
+      "Youenn Fablet"
+    ],
+    "status": "ED"
   }
 }
 </pre>

--- a/index.src.html
+++ b/index.src.html
@@ -99,6 +99,9 @@ spec: css-images-3; urlPrefix: https://www.w3.org/TR/css-images-3/
 
 spec: webrtc-svc; urlPrefix: https://w3c.github.io/webrtc-svc/
     type: dfn; text: scalability mode identifier; url:#scalabilitymodes*
+
+spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
+    type: dfn; text: the current Realm; url: #current-realm
 </pre>
 
 <pre class='biblio'>
@@ -3182,6 +3185,8 @@ interface VideoFrame {
   readonly attribute long long? timestamp;          // microseconds
   readonly attribute VideoColorSpace colorSpace;
 
+  VideoFrameMetadata getMetadata();
+
   unsigned long allocationSize(
       optional VideoFrameCopyToOptions options = {});
   Promise<sequence<PlaneLayout>> copyTo(
@@ -3204,6 +3209,8 @@ dictionary VideoFrameInit {
   // Default matches image unless visibleRect is provided.
   [EnforceRange] unsigned long displayWidth;
   [EnforceRange] unsigned long displayHeight;
+
+  VideoFrameMetadata metadata;
 };
 
 dictionary VideoFrameBufferInit {
@@ -3224,6 +3231,9 @@ dictionary VideoFrameBufferInit {
   [EnforceRange] unsigned long displayHeight;
 
   VideoColorSpaceInit colorSpace;
+};
+
+dictionary VideoFrameMetadata {
 };
 </xmp>
 
@@ -3278,6 +3288,14 @@ dictionary VideoFrameBufferInit {
 
 : <dfn attribute for=VideoFrame>[[color space]]</dfn>
 :: The {{VideoColorSpace}} associated with this frame.
+
+: <dfn attribute for=VideoFrame>\[[metadata]]</dfn>
+:: The {{VideoFrameMetadata}} associated with this frame.
+<div class='note'>
+{{VideoFrameMetadata}} is designed to be extended by other specifications.
+Specifications that do extend {{VideoFrameMetadata}} need to make sure that
+added properties are serializable.
+</div>
 
 ### Constructors ###{#videoframe-constructors}
 
@@ -3426,6 +3444,8 @@ dictionary VideoFrameBufferInit {
     9. Assign the result of running the [=VideoFrame/Pick Color Space=]
         algorithm, with |colorSpace| and {{VideoFrame/[[format]]}}, to
         {{VideoFrame/[[color space]]}}.
+    10. Assign the result of calling [=Copy VideoFrame metadata=]
+        with |init|'s {{VideoFrameInit/metadata}} to {{VideoFrame/[[metadata]]}}.
 17. Return |frame|.
 
 ### Attributes ###{#videoframe-attributes}
@@ -3624,6 +3644,12 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
 
     When invoked, run the [=Close VideoFrame=] algorithm with [=this=].
 
+: <dfn method for=VideoFrame>getMetadata()</dfn>
+:: Gets the {{VideoFrameMetadata}} associated with this frame.
+
+    When invoked, return the result of calling [=Copy VideoFrame metadata=]
+    with [=this=] {{VideoFrame/[[metadata]]}}.
+
 ### Algorithms ###{#videoframe-algorithms}
 : <dfn>Create a VideoFrame</dfn> (with |output|, |timestamp|, |duration|, |displayAspectWidth|, |displayAspectHeight|, and |colorSpace|)
 :: 1. Let |frame| be a new {{VideoFrame}}, constructed as follows:
@@ -3747,6 +3773,8 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
         |otherFrame|.{{VideoFrame/timestamp}} to
         |frame|.{{VideoFrame/timestamp}}.
     11. Assign |format| to |frame|.{{VideoFrame/[[format]]}}.
+    12. Assign the result of calling [=Copy VideoFrame metadata=]
+        with |init|'s {{VideoFrameInit/metadata}} to {{VideoFrame/metadata}}.
 
 : <dfn for=VideoFrame>Initialize Frame With Resource and Size</dfn> (with
     |init|,  |frame|, |resource|, |width| and |height|)
@@ -3825,6 +3853,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
         and {{VideoFrame/[[display height]]}}.
     5. Assign `null` to |frame|'s {{VideoFrame/[[duration]]}} and
         {{VideoFrame/[[timestamp]]}}.
+    6. Assign a new {{VideoFrameMetadata}} to |frame|'s {{VideoFrame/[[metadata]]}}.
 
 : <dfn for=VideoFrame>Parse VideoFrameCopyToOptions</dfn> (with |options|)
 ::  1. Let |defaultRect| be the result of performing the getter steps for
@@ -3997,6 +4026,13 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
         2. Assign |minAllocationSize| to
             [=combined buffer layout/allocationSize=].
     9. Return |combinedLayout|.
+
+: <dfn for=VideoFrame>Copy VideoFrame metadata</dfn> (with |metadata|)
+:: 1. Let |metadataCopySerialized| be [$StructuredSerialize$](|metadata|).
+    2. Let |metadataCopy| be [$StructuredDeserialize$](|metadataCopySerialized|, [=the current Realm=]).
+    3. return |metadataCopy|.
+
+The goal of this algorithm is to ensure that metadata owned by a {{VideoFrame}} is immutable.
 
 ### Transfer and Serialization ###{#videoframe-transfer-serialization}
 

--- a/index.src.html
+++ b/index.src.html
@@ -3650,8 +3650,11 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
 : <dfn method for=VideoFrame>metadata()</dfn>
 :: Gets the {{VideoFrameMetadata}} associated with this frame.
 
-    When invoked, return the result of calling [=Copy VideoFrame metadata=]
-    with [=this=] {{VideoFrame/[[metadata]]}}.
+    When invoked, run these steps:
+    1. If {{platform object/[[Detached]]}} is <code>true</code>,
+        throw an {{InvalidStateError}} {{DOMException}}.
+    2. Return the result of calling [=Copy VideoFrame metadata=]
+        with {{VideoFrame/[[metadata]]}}.
 
 ### Algorithms ###{#videoframe-algorithms}
 : <dfn>Create a VideoFrame</dfn> (with |output|, |timestamp|, |duration|, |displayAspectWidth|, |displayAspectHeight|, and |colorSpace|)

--- a/video_frame_metadata_registry.src.html
+++ b/video_frame_metadata_registry.src.html
@@ -30,12 +30,12 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
 Registration Entry Requirements {#registration-entry-requirements}
 ==================================================================
 
-A registration entry is a document describing one or several metadata entry.
-A registrating entry has the following requirements:
+A registration entry is a document describing one or several metadata entry,
+and has the following requirements:
 1. Each metadata entry is defined as a separate {{VideoFrameMetadata}}
     dictionary member.
-2. Each metadata entry MUST be serializable.
-3. Each metadata entry should have clearly defined semantics.
+2. Each metadata entry must be serializable.
+3. Each metadata must be defined by a W3C specification and have clearly defined semantics.
     In particular, its interactions with the media processing pipeline
     (encoders, decoders, renderers, etc.) should be well defined.
 4. A candidate registration entry must be announced by filing an issue in the

--- a/video_frame_metadata_registry.src.html
+++ b/video_frame_metadata_registry.src.html
@@ -43,7 +43,7 @@ A registrating entry has the following requirements:
     compliance before being added to the registry. If the Media Working Group
     reaches consensus to accept the candidate, a pull request should be drafted
     (either by editors or by the party requesting the candidate registration)
-    to register the candidate.The registry editors will review and merge the
+    to register the candidate. The registry editors will review and merge the
     pull request.
 
 VideoFrameMetadata definition {#videoframemetadata-definition}

--- a/video_frame_metadata_registry.src.html
+++ b/video_frame_metadata_registry.src.html
@@ -1,18 +1,18 @@
 <pre class='metadata'>
 Title: WebCodecs VideoFrame Metadata Registry
 Repository: w3c/webcodecs
-Status: NOTE-ED
-Shortname: webcodecs-videoframemetadata-registry
+Status: DRY
+Shortname: webcodecs-video-frame-metadata-registry
 Level: none
 Group: mediawg
-ED: https://w3c.github.io/webcodecs/videoframemetadata_registry.html
-TR: https://www.w3.org/TR/webcodecs-videoframemetadata-registry/
-Editor:
+ED: https://w3c.github.io/webcodecs/video-frame-metadata-registry.html
+TR: https://www.w3.org/TR/webcodecs-video-frame-metadata-registry/
+Editor: Youenn Fablet, w3cid 96458, Apple Inc., youenn@apple.com
 
 Boilerplate: omit conformance
 
 Abstract: This registry is intended to enumerate the metadata fields that can be attached
-    to {{VideoFrame}} objects via the {{VideoFrameMetadata}} dictionary..
+    to {{VideoFrame}} objects via the {{VideoFrameMetadata}} dictionary.
 
 Markup Shorthands:css no, markdown yes, dfn yes
 !Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
@@ -30,32 +30,41 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
 Registration Entry Requirements {#registration-entry-requirements}
 ==================================================================
 
-A registration entry, called metadata, has the following requirements:
-1. Each metadata is defined as a separate {{VideoFrameMetadata}} dictionary member.
-2. Each metadata MUST be serializable.
-3. Each metadata should have clearly defined semantics.
-   In particular, its interactions with the media processing pipeline
-   (encoders, decoders, renderers...) should be well defined.
+A registration entry is a document describing one or several metadata entry.
+A registrating entry has the following requirements:
+1. Each metadata entry is defined as a separate {{VideoFrameMetadata}}
+    dictionary member.
+2. Each metadata entry MUST be serializable.
+3. Each metadata entry should have clearly defined semantics.
+    In particular, its interactions with the media processing pipeline
+    (encoders, decoders, renderers, etc.) should be well defined.
+4. A candidate registration entry must be announced by filing an issue in the
+    WebCodecs GitHub issue tracker so they can be discussed and evaluated for
+    compliance before being added to the registry. If the Media Working Group
+    reaches consensus to accept the candidate, a pull request should be drafted
+    (either by editors or by the party requesting the candidate registration)
+    to register the candidate.The registry editors will review and merge the
+    pull request.
 
-VideoFrameMetadata definition
-============================================
+VideoFrameMetadata definition {#videoframemetadata-definition}
+=============================================================
 <xmp class='idl'>
 dictionary VideoFrameMetadata {
 };
 </xmp>
 
-VideoFrameMetadata members
-============================================
+VideoFrameMetadata members {#videoframemetadata-members}
+========================================================
 
 
 Privacy Considerations {#privacy-considerations}
-==========================================================================
+================================================
 
 Please refer to the section [[WEBCODECS#privacy-considerations|Privacy
 Considerations]] in [[WEBCODECS]].
 
 Security Considerations {#security-considerations}
-==========================================================================
+==================================================
 
 Please refer to the section [[WEBCODECS#security-considerations|Security
 Considerations]] in [[WEBCODECS]].

--- a/video_frame_metadata_registry.src.html
+++ b/video_frame_metadata_registry.src.html
@@ -1,0 +1,61 @@
+<pre class='metadata'>
+Title: WebCodecs VideoFrame Metadata Registry
+Repository: w3c/webcodecs
+Status: NOTE-ED
+Shortname: webcodecs-videoframemetadata-registry
+Level: none
+Group: mediawg
+ED: https://w3c.github.io/webcodecs/videoframemetadata_registry.html
+TR: https://www.w3.org/TR/webcodecs-videoframemetadata-registry/
+Editor:
+
+Boilerplate: omit conformance
+
+Abstract: This registry is intended to enumerate the metadata fields that can be attached
+    to {{VideoFrame}} objects via the {{VideoFrameMetadata}} dictionary..
+
+Markup Shorthands:css no, markdown yes, dfn yes
+!Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
+!Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
+!Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
+</pre>
+
+<pre class='anchors'>
+spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
+    type: dictionary
+        text: VideoFrame; url: dictdef-videoframe
+</pre>
+
+
+Registration Entry Requirements {#registration-entry-requirements}
+==================================================================
+
+A registration entry, called metadata, has the following requirements:
+1. Each metadata is defined as a separate {{VideoFrameMetadata}} dictionary member.
+2. Each metadata MUST be serializable.
+3. Each metadata should have clearly defined semantics.
+   In particular, its interactions with the media processing pipeline
+   (encoders, decoders, renderers...) should be well defined.
+
+VideoFrameMetadata definition
+============================================
+<xmp class='idl'>
+dictionary VideoFrameMetadata {
+};
+</xmp>
+
+VideoFrameMetadata members
+============================================
+
+
+Privacy Considerations {#privacy-considerations}
+==========================================================================
+
+Please refer to the section [[WEBCODECS#privacy-considerations|Privacy
+Considerations]] in [[WEBCODECS]].
+
+Security Considerations {#security-considerations}
+==========================================================================
+
+Please refer to the section [[WEBCODECS#security-considerations|Security
+Considerations]] in [[WEBCODECS]].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webcodecs/pull/559.html" title="Last updated on Oct 20, 2022, 8:20 AM UTC (8b59018)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/559/938df12...youennf:8b59018.html" title="Last updated on Oct 20, 2022, 8:20 AM UTC (8b59018)">Diff</a>