### PR TITLE
Add spec text for serializable encoded chunks.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2441,7 +2441,7 @@ These interfaces represent chunks of encoded media.
 EncodedAudioChunk Interface {#encodedaudiochunk-interface}
 ------------------------------------------------------------
 <xmp class='idl'>
-[Exposed=(Window,DedicatedWorker)]
+[Exposed=(Window,DedicatedWorker), Serializable]
 interface EncodedAudioChunk {
   constructor(EncodedAudioChunkInit init);
   readonly attribute EncodedAudioChunkType type;
@@ -2510,10 +2510,28 @@ enum EncodedAudioChunkType {
         greater than in |destination|, throw a {{TypeError}}.
     2. Copy the {{EncodedAudioChunk/[[internal data]]}} into |destination|.
 
+### Serialization ###{#encodedaudiochunk-serialization}
+: The {{EncodedAudioChunk}} [=serialization steps=] (with |value|, |serialized|,
+    and |forStorage|) are:
+:: 1. If |forStorage| is `true`, throw a {{TypeError}}.
+    2. For each {{EncodedAudioChunk}} internal slot in |value|, assign the value
+        of each internal slot to a field in |serialized| with the same name
+        the internal slot.
+
+: The {{EncodedAudioChunk}} [=deserialization steps=] (with |serialized| and
+    |value|) are:
+:: 1. For all named fields in |serialized|, assign the value of each named field
+        to the {{EncodedAudioChunk}} internal slot in |value| with the same name
+        as the named field.
+
+NOTE: Since {{EncodedAudioChunk}}s are immutable, User Agents may choose to
+    implement serialization using a reference counting model similar to
+    [[#audiodata-transfer-serialization]].
+
 EncodedVideoChunk Interface{#encodedvideochunk-interface}
 -----------------------------------------------------------
 <xmp class='idl'>
-[Exposed=(Window,DedicatedWorker)]
+[Exposed=(Window,DedicatedWorker), Serializable]
 interface EncodedVideoChunk {
   constructor(EncodedVideoChunkInit init);
   readonly attribute EncodedVideoChunkType type;
@@ -2583,6 +2601,24 @@ enum EncodedVideoChunkType {
         the {{EncodedVideoChunk/[[byte length]]}} of |destination|, throw a
         {{TypeError}}.
     2. Copy the {{EncodedVideoChunk/[[internal data]]}} into |destination|.
+
+### Serialization ###{#encodedvideochunk-serialization}
+: The {{EncodedVideoChunk}} [=serialization steps=] (with |value|, |serialized|,
+    and |forStorage|) are:
+:: 1. If |forStorage| is `true`, throw a {{TypeError}}.
+    2. For each {{EncodedVideoChunk}} internal slot in |value|, assign the value
+        of each internal slot to a field in |serialized| with the same name
+        the internal slot.
+
+: The {{EncodedVideoChunk}} [=deserialization steps=] (with |serialized| and
+    |value|) are:
+:: 1. For all named fields in |serialized|, assign the value of each named field
+        to the {{EncodedVideoChunk}} internal slot in |value| with the same name
+        as the named field.
+
+NOTE: Since {{EncodedVideoChunk}}s are immutable, User Agents may choose to
+    implement serialization using a reference counting model similar to
+    [[#videoframe-transfer-serialization]].
 
 
 Raw Media Interfaces {#raw-media-interfaces}

--- a/index.src.html
+++ b/index.src.html
@@ -2515,7 +2515,7 @@ enum EncodedAudioChunkType {
     and |forStorage|) are:
 :: 1. If |forStorage| is `true`, throw a {{TypeError}}.
     2. For each {{EncodedAudioChunk}} internal slot in |value|, assign the value
-        of each internal slot to a field in |serialized| with the same name
+        of each internal slot to a field in |serialized| with the same name as
         the internal slot.
 
 : The {{EncodedAudioChunk}} [=deserialization steps=] (with |serialized| and
@@ -2607,7 +2607,7 @@ enum EncodedVideoChunkType {
     and |forStorage|) are:
 :: 1. If |forStorage| is `true`, throw a {{TypeError}}.
     2. For each {{EncodedVideoChunk}} internal slot in |value|, assign the value
-        of each internal slot to a field in |serialized| with the same name
+        of each internal slot to a field in |serialized| with the same name as
         the internal slot.
 
 : The {{EncodedVideoChunk}} [=deserialization steps=] (with |serialized| and


### PR DESCRIPTION
Chromium launched with this support, but apparently the spec text was never updated. Sorry about that!

Fixes: #289


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/567.html" title="Last updated on Sep 28, 2022, 7:34 PM UTC (0913cb5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/567/1db4c21...0913cb5.html" title="Last updated on Sep 28, 2022, 7:34 PM UTC (0913cb5)">Diff</a>