### PR TITLE
Remove EnforceRange to framerate definition since EnforceRange is only for integer types

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2102,7 +2102,7 @@ dictionary VideoEncoderConfig {
   [EnforceRange] unsigned long displayWidth;
   [EnforceRange] unsigned long displayHeight;
   [EnforceRange] unsigned long long bitrate;
-  [EnforceRange] double framerate;
+  double framerate;
   HardwareAcceleration hardwareAcceleration = "no-preference";
   AlphaOption alpha = "discard";
   DOMString scalabilityMode;


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webcodecs/pull/568.html" title="Last updated on Oct 3, 2022, 9:12 AM UTC (29f77a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/568/ae7ca0a...youennf:29f77a5.html" title="Last updated on Oct 3, 2022, 9:12 AM UTC (29f77a5)">Diff</a>