### PR TITLE
Fix close algorithm for non-null VideoFrame timestamps.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3830,8 +3830,6 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
         {{VideoFrame/[[visible top]]}}, {{VideoFrame/[[visible width]]}},
         {{VideoFrame/[[visible height]]}}, {{VideoFrame/[[display width]]}},
         and {{VideoFrame/[[display height]]}}.
-    5. Assign `null` to |frame|'s {{VideoFrame/[[duration]]}} and
-        {{VideoFrame/[[timestamp]]}}.
 
 : <dfn for=VideoFrame>Parse VideoFrameCopyToOptions</dfn> (with |options|)
 ::  1. Let |defaultRect| be the result of performing the getter steps for


### PR DESCRIPTION
@Timestamp shouldn't be null anymore, so remove language around setting it to null.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/570.html" title="Last updated on Sep 29, 2022, 9:17 PM UTC (f04c684)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/570/1db4c21...f04c684.html" title="Last updated on Sep 29, 2022, 9:17 PM UTC (f04c684)">Diff</a>