### PR TITLE
RGBA sample size is 32 bits

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4373,7 +4373,8 @@ is its own [=equivalent opaque format=].
     This format is composed of a single plane, that encodes four components:
     Red, Green, Blue, and an alpha value, present in this order.
 
-    Each sample in this format is 8 bits, and each pixel is therefore 32 bits.
+    Each sample in this format is 32 bits, corresponding to the four 8 bits
+    values packed consecutively, one for each component.
 
     There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} * 4 samples
     (and therefore bytes) in the single plane, arranged starting at the top

--- a/index.src.html
+++ b/index.src.html
@@ -4376,7 +4376,7 @@ is its own [=equivalent opaque format=].
     Each sample in this format is 32 bits, corresponding to the four 8 bits
     values packed consecutively, one for each component.
 
-    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} * 4 samples
+    There are {{VideoFrame/codedWidth}} * {{VideoFrame/codedHeight}} * samples
     (and therefore bytes) in the single plane, arranged starting at the top
     left in the image, in {{VideoFrame/codedHeight}} lines of
     {{VideoFrame/codedWidth}} samples.


### PR DESCRIPTION
This fixes #573.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/579.html" title="Last updated on Oct 11, 2022, 11:07 AM UTC (3d19040)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/579/55ca05e...3d19040.html" title="Last updated on Oct 11, 2022, 11:07 AM UTC (3d19040)">Diff</a>