### PR TITLE
Move note on meaningful timestamp to VideoFrame constructor

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3332,6 +3332,14 @@ dictionary VideoFrameBufferInit {
     {{DOMException}}.
 3. Let |frame| be a new {{VideoFrame}}.
 5. Switch on |image|:
+
+    NOTE: Authors are encouraged to provide a meaningful timestamp unless it is
+        implicitly provided by the {{CanvasImageSource}} at construction.
+        Interfaces that consume {{VideoFrame}}s can rely on this value for
+        timing decisions. For example, {{VideoEncoder}} can use
+        {{VideoFrame/timestamp}} values to guide rate control (see
+        {{VideoEncoderConfig/framerate}}).
+
     - {{HTMLImageElement}}
     - {{SVGImageElement}}
         1. If {{VideoFrameInit/timestamp}} does not [=map/exist=] in
@@ -3541,13 +3549,6 @@ dictionary VideoFrameBufferInit {
 
     The {{VideoFrame/timestamp}} getter steps are to return
     {{VideoFrame/[[timestamp]]}}.
-
-    NOTE: Authors are encouraged to provide a meaningful timestamp unless it is
-        implicitly provided by the {{CanvasImageSource}} at construction.
-        Interfaces that consume {{VideoFrame}}s can rely on this value for
-        timing decisions. For example, {{VideoEncoder}} can use
-        {{VideoFrame/timestamp}} values to guide rate control (see
-        {{VideoEncoderConfig/framerate}}).
 
 : <dfn attribute for=VideoFrame>duration</dfn>
 :: The presentation duration, given in microseconds. The duration is copied


### PR DESCRIPTION
it really is about the timestamp in VideoFrameInit, not the attribute of VideoFrame


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/webcodecs/pull/587.html" title="Last updated on Oct 19, 2022, 3:08 PM UTC (1aef32c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/587/9ad546a...dontcallmedom:1aef32c.html" title="Last updated on Oct 19, 2022, 3:08 PM UTC (1aef32c)">Diff</a>