### PR TITLE
When serializing some WebCodecs objects with `forStorage=true`, throw `DataCloneError` instead of `TypeError`

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2516,7 +2516,7 @@ enum EncodedAudioChunkType {
 ### Serialization ###{#encodedaudiochunk-serialization}
 : The {{EncodedAudioChunk}} [=serialization steps=] (with |value|, |serialized|,
     and |forStorage|) are:
-:: 1. If |forStorage| is `true`, throw a {{TypeError}}.
+:: 1. If |forStorage| is `true`, throw a {{DataCloneError}}.
     2. For each {{EncodedAudioChunk}} internal slot in |value|, assign the value
         of each internal slot to a field in |serialized| with the same name as
         the internal slot.
@@ -2608,7 +2608,7 @@ enum EncodedVideoChunkType {
 ### Serialization ###{#encodedvideochunk-serialization}
 : The {{EncodedVideoChunk}} [=serialization steps=] (with |value|, |serialized|,
     and |forStorage|) are:
-:: 1. If |forStorage| is `true`, throw a {{TypeError}}.
+:: 1. If |forStorage| is `true`, throw a {{DataCloneError}}.
     2. For each {{EncodedVideoChunk}} internal slot in |value|, assign the value
         of each internal slot to a field in |serialized| with the same name as
         the internal slot.
@@ -2974,7 +2974,7 @@ Note: It's expected that {{AudioDataInit}}'s {{AudioDataInit/data}}'s memory
     |forStorage|) are:
 :: 1. If |value|'s {{platform object/[[Detached]]}} is `true`, throw a
         {{DataCloneError}} {{DOMException}}.
-    2. If |forStorage| is `true`, throw a {{TypeError}}.
+    2. If |forStorage| is `true`, throw a {{DataCloneError}}.
     3. Let |resource| be the [=media resource=] referenced by
             |value|'s {{AudioData/[[resource reference]]}}.
     4. Let |newReference| be a new reference to |resource|.
@@ -4064,7 +4064,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
     |forStorage|) are:
 :: 1. If |value|'s {{platform object/[[Detached]]}} is `true`, throw a
         {{DataCloneError}} {{DOMException}}.
-    2. If |forStorage| is `true`, throw a {{TypeError}}.
+    2. If |forStorage| is `true`, throw a {{DataCloneError}}.
     3. Let |resource| be the [=media resource=] referenced by
             |value|'s {{VideoFrame/[[resource reference]]}}.
     4. Let |newReference| be a new reference to |resource|.


### PR DESCRIPTION
This applies to `EncodedVideoChunk`, `EncodedAudioChunk`, `AudioData` and `VideoFrame`, and fixes issue #589.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/590.html" title="Last updated on Oct 20, 2022, 7:09 AM UTC (bc750fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/590/34b6ed2...bc750fd.html" title="Last updated on Oct 20, 2022, 7:09 AM UTC (bc750fd)">Diff</a>