### PR TITLE
Add null defaults to VideoColorSpaceInit members

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4444,10 +4444,10 @@ interface VideoColorSpace {
 };
 
 dictionary VideoColorSpaceInit {
-  VideoColorPrimaries? primaries;
-  VideoTransferCharacteristics? transfer;
-  VideoMatrixCoefficients? matrix;
-  boolean? fullRange;
+  VideoColorPrimaries? primaries = null;
+  VideoTransferCharacteristics? transfer = null;
+  VideoMatrixCoefficients? matrix = null;
+  boolean? fullRange = null;
 };
 </xmp>
 
@@ -4466,18 +4466,10 @@ dictionary VideoColorSpaceInit {
   VideoColorSpace(init)
 </dfn>
 1. Let |c| be a new {{VideoColorSpace}} object, initialized as follows:
-    1. If `primaries` is present in `init`, assign `init.primaries` to
-        {{VideoColorSpace/[[primaries]]}}. Otherwise, assign `null` to
-        {{VideoColorSpace/[[primaries]]}}.
-    2. If `transfer` is present in `init`, assign `init.transfer` to
-        {{VideoColorSpace/[[transfer]]}}. Otherwise, assign `null` to
-        {{VideoColorSpace/[[transfer]]}}.
-    3. If `matrix` is present in `init`, assign `init.matrix` to
-        {{VideoColorSpace/[[matrix]]}}. Otherwise, assign `null` to
-        {{VideoColorSpace/[[matrix]]}}.
-    4. If `fullRange` is present in `init`, assign `init.fullRange` to
-        {{VideoColorSpace/[[full range]]}}. Otherwise, assign `null` to
-        {{VideoColorSpace/[[full range]]}}.
+    1. Assign `init.primaries` to {{VideoColorSpace/[[primaries]]}}.
+    2. Assign `init.transfer` to {{VideoColorSpace/[[transfer]]}}.
+    3. Assign `init.matrix` to {{VideoColorSpace/[[matrix]]}}.
+    4. Assign `init.fullRange` to {{VideoColorSpace/[[full range]]}}.
 6. Return |c|.
 
 ### Attributes ### {#videocolorspace-attributes}


### PR DESCRIPTION
No need to do in prose what Web IDL can achieve.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webcodecs/pull/591.html" title="Last updated on Oct 20, 2022, 7:40 AM UTC (a6d5c71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/591/34b6ed2...tidoust:a6d5c71.html" title="Last updated on Oct 20, 2022, 7:40 AM UTC (a6d5c71)">Diff</a>