### PR TITLE
Add OpusEncoderConfig parameters

### DIFF
--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -172,7 +172,7 @@ To check if an {{OpusEncoderConfig}} is valid, run these steps:
     Configures the encoder's expected packet loss percentage. The valid range is
     `0` to `100`.
 
-    NOTE: The packet loss percentage might be updated over the course of the
+    NOTE: The packet loss percentage might be updated over the course of an
     encoding, and it is recommended for User Agents to support these reconfigurations.
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>useinbandfec</dfn></dt>

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -131,9 +131,9 @@ OpusEncoderConfig {#opus-encoder-config}
 <xmp>
 dictionary OpusEncoderConfig {
   OpusBitstreamFormat format = "opus";
-  [EnforceRange] unsigned long frameDuration;
+  [EnforceRange] unsigned long frameDuration = 20;
   [EnforceRange] unsigned long complexity;
-  [EnforceRange] unsigned long packetlossperc;
+  [EnforceRange] unsigned long packetlossperc = 0;
   boolean useinbandfec = false;
   boolean usedtx = false;
 };
@@ -158,24 +158,31 @@ To check if an {{OpusEncoderConfig}} is valid, run these steps:
   <dt><dfn dict-member for=OpusEncoderConfig>frameDuration</dfn></dt>
   <dd>
     Configures the frame duration, in milliseconds, of output {{EncodedAudioChunk}}s.
+    If not specified, the default is `20` milliseconds.
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>complexity</dfn></dt>
   <dd>
     Configures the encoder's computational complexity. The valid range is `0` to `10`,
-    with `10` representing the highest complexity.
+    with `10` representing the highest complexity. If no value is specificied, the
+    default value is platform-specific: User Agents <em class="rfc2119">SHOULD</em>
+    set a default of `5` for mobile platforms, and a default of `9` for all other platforms.
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>packetlossperc</dfn></dt>
   <dd>
     Configures the encoder's expected packet loss percentage. The valid range is
-    `0` to `100`.
+    `0` to `100`. If no value is specified, the default is `0`.
+
+    NOTE: The packet loss percentage might be updated over the course of the encoding, and
+      it is recommended for User Agents to support these reconfigurations.
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>useinbandfec</dfn></dt>
   <dd>
-    Configures whether the encoder should generate Opus in-band fec or not.
+    Specifies whether the encoder provides Opus in-band FEC. If no value is specified,
+    the default is `false`.
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>usedtx</dfn></dt>
   <dd>
-    Configures whether the encoder should use DTX or not.
+    Specifies if the encoder uses DTX. If no value is specified, the default is `false`.
   </dd>
 </dl>
 

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -131,7 +131,7 @@ OpusEncoderConfig {#opus-encoder-config}
 <xmp>
 dictionary OpusEncoderConfig {
   OpusBitstreamFormat format = "opus";
-  [EnforceRange] unsigned long frameDuration = 20;
+  [EnforceRange] unsigned long frameDuration;
   [EnforceRange] unsigned long complexity;
   [EnforceRange] unsigned long packetlossperc = 0;
   boolean useinbandfec = false;
@@ -161,26 +161,28 @@ To check if an {{OpusEncoderConfig}} is valid, run these steps:
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>complexity</dfn></dt>
   <dd>
-    Configures the encoder's computational complexity. The valid range is `0` to `10`,
-    with `10` representing the highest complexity. If no value is specificied, the
-    default value is platform-specific: User Agents <em class="rfc2119">SHOULD</em>
-    set a default of `5` for mobile platforms, and a default of `9` for all other platforms.
+    Configures the encoder's computational complexity, as described 2.1.9. of
+    [[RFC6716]]. The valid range is `0` to `10`, with `10` representing the highest
+    complexity. If no value is specificied, the default value is platform-specific:
+    User Agents <em class="rfc2119">SHOULD</em> set a default of `5` for mobile
+    platforms, and a default of `9` for all other platforms.
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>packetlossperc</dfn></dt>
   <dd>
     Configures the encoder's expected packet loss percentage. The valid range is
     `0` to `100`.
 
-    NOTE: The packet loss percentage might be updated over the course of the encoding, and
-      it is recommended for User Agents to support these reconfigurations.
+    NOTE: The packet loss percentage might be updated over the course of the
+    encoding, and it is recommended for User Agents to support these reconfigurations.
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>useinbandfec</dfn></dt>
   <dd>
-    Specifies whether the encoder provides Opus in-band FEC.
+    Specifies whether the encoder provides Opus in-band FEC, as described by
+    section 2.1.7. of [[RFC6716]].
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>usedtx</dfn></dt>
   <dd>
-    Specifies if the encoder uses DTX.
+    Specifies if the encoder uses DTX, as described by section 2.1.9. of [[RFC6716]].
   </dd>
 </dl>
 

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -158,7 +158,6 @@ To check if an {{OpusEncoderConfig}} is valid, run these steps:
   <dt><dfn dict-member for=OpusEncoderConfig>frameDuration</dfn></dt>
   <dd>
     Configures the frame duration, in milliseconds, of output {{EncodedAudioChunk}}s.
-    If not specified, the default is `20` milliseconds.
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>complexity</dfn></dt>
   <dd>
@@ -170,19 +169,18 @@ To check if an {{OpusEncoderConfig}} is valid, run these steps:
   <dt><dfn dict-member for=OpusEncoderConfig>packetlossperc</dfn></dt>
   <dd>
     Configures the encoder's expected packet loss percentage. The valid range is
-    `0` to `100`. If no value is specified, the default is `0`.
+    `0` to `100`.
 
     NOTE: The packet loss percentage might be updated over the course of the encoding, and
       it is recommended for User Agents to support these reconfigurations.
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>useinbandfec</dfn></dt>
   <dd>
-    Specifies whether the encoder provides Opus in-band FEC. If no value is specified,
-    the default is `false`.
+    Specifies whether the encoder provides Opus in-band FEC.
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>usedtx</dfn></dt>
   <dd>
-    Specifies if the encoder uses DTX. If no value is specified, the default is `false`.
+    Specifies if the encoder uses DTX.
   </dd>
 </dl>
 

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -132,6 +132,10 @@ OpusEncoderConfig {#opus-encoder-config}
 dictionary OpusEncoderConfig {
   OpusBitstreamFormat format = "opus";
   [EnforceRange] unsigned long frameDuration;
+  [EnforceRange] unsigned long complexity;
+  [EnforceRange] unsigned long packetlossperc;
+  boolean useinbandfec;
+  boolean usedtx;
 };
 </xmp>
 </pre>
@@ -139,6 +143,10 @@ dictionary OpusEncoderConfig {
 To check if an {{OpusEncoderConfig}} is valid, run these steps:
 1. If {{OpusEncoderConfig/frameDuration}} is not a valid `ptime` value,
     which is described in Section 6.1 of [[RFC7587]], return `false`.
+1. If {{OpusEncoderConfig/complexity}} is specified and not within the range of
+    `0` and `10` inclusively, return `false`.
+1. If {{OpusEncoderConfig/packetlossperc}} is specified and not within the range of
+    `0` and `100` inclusively, return `false`.
 2. Return `true`.
 
 <dl>
@@ -150,6 +158,24 @@ To check if an {{OpusEncoderConfig}} is valid, run these steps:
   <dt><dfn dict-member for=OpusEncoderConfig>frameDuration</dfn></dt>
   <dd>
     Configures the frame duration, in milliseconds, of output {{EncodedAudioChunk}}s.
+  </dd>
+  <dt><dfn dict-member for=OpusEncoderConfig>complexity</dfn></dt>
+  <dd>
+    Configures the encoder's computational complexity. The valid range is `0` to `10`,
+    with `10` representing the highest complexity.
+  </dd>
+  <dt><dfn dict-member for=OpusEncoderConfig>packetlossperc</dfn></dt>
+  <dd>
+    Configures the encoder's expected packet loss percentage. The valid range is
+    `0` to `100`.
+  </dd>
+  <dt><dfn dict-member for=OpusEncoderConfig>useinbandfec</dfn></dt>
+  <dd>
+    Configures whether the encoder should generate Opus in-band fec or not.
+  </dd>
+  <dt><dfn dict-member for=OpusEncoderConfig>usedtx</dfn></dt>
+  <dd>
+    Configures whether the encoder should use DTX or not.
   </dd>
 </dl>
 

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -161,8 +161,8 @@ To check if an {{OpusEncoderConfig}} is valid, run these steps:
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>complexity</dfn></dt>
   <dd>
-    Configures the encoder's computational complexity, as described 2.1.9. of
-    [[RFC6716]]. The valid range is `0` to `10`, with `10` representing the highest
+    Configures the encoder's computational complexity, as described in section 2.1.9.
+    of [[RFC6716]]. The valid range is `0` to `10`, with `10` representing the highest
     complexity. If no value is specificied, the default value is platform-specific:
     User Agents <em class="rfc2119">SHOULD</em> set a default of `5` for mobile
     platforms, and a default of `9` for all other platforms.
@@ -177,12 +177,13 @@ To check if an {{OpusEncoderConfig}} is valid, run these steps:
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>useinbandfec</dfn></dt>
   <dd>
-    Specifies whether the encoder provides Opus in-band FEC, as described by
-    section 2.1.7. of [[RFC6716]].
+    Specifies whether the encoder provides Opus in-band Forward Error Correction
+    (FEC), as described by section 2.1.7. of [[RFC6716]].
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>usedtx</dfn></dt>
   <dd>
-    Specifies if the encoder uses DTX, as described by section 2.1.9. of [[RFC6716]].
+    Specifies if the encoder uses Discontinuous Transmission (DTX), as described
+    by section 2.1.9. of [[RFC6716]].
   </dd>
 </dl>
 

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -134,8 +134,8 @@ dictionary OpusEncoderConfig {
   [EnforceRange] unsigned long frameDuration;
   [EnforceRange] unsigned long complexity;
   [EnforceRange] unsigned long packetlossperc;
-  boolean useinbandfec;
-  boolean usedtx;
+  boolean useinbandfec = false;
+  boolean usedtx = false;
 };
 </xmp>
 </pre>


### PR DESCRIPTION
This PR adds in-band-FEC, DTX and complexity configuration knobs to the Opus encoder.

This should fix #244 and #527