### PR TITLE
Move VideoFrameMetadata dfn to WebCodecs

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -100,9 +100,6 @@ spec: css-images-3; urlPrefix: https://www.w3.org/TR/css-images-3/
 spec: webrtc-svc; urlPrefix: https://w3c.github.io/webrtc-svc/
     type: dfn; text: scalability mode identifier; url:#scalabilitymodes*
 
-spec: webcodecs-video-frame-metadata-registry; urlPrefix: https://w3c.github.io/webcodecs/video-frame-metadata-registry.html
-    type: dictionary; text: VideoFrameMetadata; url: dictdef-videoframemetadata
-
 spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     type: dfn; text: the current Realm; url: #current-realm
 </pre>
@@ -3283,6 +3280,10 @@ dictionary VideoFrameBufferInit {
 
   VideoColorSpaceInit colorSpace;
 };
+
+dictionary VideoFrameMetadata {
+  // Possible members are recorded in the VideoFrame Metadata Registry.
+};
 </xmp>
 
 ### Internal Slots ###{#videoframe-internal-slots}
@@ -3339,8 +3340,8 @@ dictionary VideoFrameBufferInit {
 
 : <dfn attribute for=VideoFrame>\[[metadata]]</dfn>
 :: The {{VideoFrameMetadata}} associated with this frame.
-     {{VideoFrameMetadata}} is defined in [[webcodecs-video-frame-metadata-registry]].
-     By design, all {{VideoFrameMetadata}} properties are serializable.
+    Possible members are recorded in [[webcodecs-video-frame-metadata-registry]].
+    By design, all {{VideoFrameMetadata}} properties are serializable.
 
 ### Constructors ###{#videoframe-constructors}
 

--- a/video_frame_metadata_registry.src.html
+++ b/video_frame_metadata_registry.src.html
@@ -1,7 +1,7 @@
 <pre class='metadata'>
 Title: WebCodecs VideoFrame Metadata Registry
 Repository: w3c/webcodecs
-Status: DRY
+Status: ED
 Shortname: webcodecs-video-frame-metadata-registry
 Level: none
 Group: mediawg
@@ -24,6 +24,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: dictionary
         text: VideoFrame; url: dictdef-videoframe
+        text: VideoFrameMetadata; url: dictdef-videoframemetadata
 </pre>
 
 
@@ -45,13 +46,6 @@ and has the following requirements:
     (either by editors or by the party requesting the candidate registration)
     to register the candidate. The registry editors will review and merge the
     pull request.
-
-VideoFrameMetadata definition {#videoframemetadata-definition}
-=============================================================
-<xmp class='idl'>
-dictionary VideoFrameMetadata {
-};
-</xmp>
 
 VideoFrameMetadata members {#videoframemetadata-members}
 ========================================================


### PR DESCRIPTION
A registry cannot contain normative IDL, so the base definition of the `VideoFrameMetadata` dictionary should remain in WebCodecs.

Also note that while the registry will be published as a "W3C Draft Registry", the document in the repo remains an "Editor's Draft". Updating the status accordingly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webcodecs/pull/596.html" title="Last updated on Oct 21, 2022, 12:18 PM UTC (faef414)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/596/d7edc37...tidoust:faef414.html" title="Last updated on Oct 21, 2022, 12:18 PM UTC (faef414)">Diff</a>