### PR TITLE
Fix link to VideoFrame

### DIFF
--- a/video_frame_metadata_registry.src.html
+++ b/video_frame_metadata_registry.src.html
@@ -23,7 +23,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 <pre class='anchors'>
 spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: dictionary
-        text: VideoFrame; url: dictdef-videoframe
+        text: VideoFrame; url: videoframe-interface
         text: VideoFrameMetadata; url: dictdef-videoframemetadata
 </pre>
 


### PR DESCRIPTION
This PR fixes the link to the VideoFrame definition in the VideoFrame Metadata Registry.