### PR TITLE
Mark Chris as a former editor of WebCodecs specs.

### DIFF
--- a/aac_codec_registration.src.html
+++ b/aac_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/aac_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-aac-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for AAC, the (1) fully qualified codec strings, (2) the

--- a/alaw_codec_registration.src.html
+++ b/alaw_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/alaw_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-alaw-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for A-law encoded PCM, the (1) fully qualified codec strings,

--- a/av1_codec_registration.src.html
+++ b/av1_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/av1_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-av1-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for AV1, the (1) fully qualified codec strings,

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/avc_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-avc-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for AVC (H.264), the (1) fully qualified codec strings,

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/codec_registry.html
 TR: https://www.w3.org/TR/webcodecs-codec-registry/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Boilerplate: omit conformance
 

--- a/flac_codec_registration.src.html
+++ b/flac_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/flac_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-flac-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for FLAC, the (1) fully qualified codec strings,

--- a/hevc_codec_registration.src.html
+++ b/hevc_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/hevc_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-hevc-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for HEVC (H.265), the (1) fully qualified codec strings,

--- a/index.src.html
+++ b/index.src.html
@@ -7,9 +7,9 @@ TR: https://www.w3.org/TR/webcodecs/
 Shortname: webcodecs
 Level: None
 Group: mediawg
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This specification defines interfaces to codecs for encoding and
     decoding of audio, video, and images.

--- a/mp3_codec_registration.src.html
+++ b/mp3_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/mp3_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-mp3-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for MP3, the (1) fully qualified codec strings, (2)

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/opus_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-opus-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for Opus, the (1) fully qualified codec strings, (2) the
@@ -158,32 +158,6 @@ To check if an {{OpusEncoderConfig}} is valid, run these steps:
   <dt><dfn dict-member for=OpusEncoderConfig>frameDuration</dfn></dt>
   <dd>
     Configures the frame duration, in microseconds, of output {{EncodedAudioChunk}}s.
-  </dd>
-  <dt><dfn dict-member for=OpusEncoderConfig>complexity</dfn></dt>
-  <dd>
-    Configures the encoder's computational complexity, as described in section 2.1.9.
-    of [[RFC6716]]. The valid range is `0` to `10`, with `10` representing the highest
-    complexity. If no value is specificied, the default value is platform-specific:
-    User Agents <em class="rfc2119">SHOULD</em> set a default of `5` for mobile
-    platforms, and a default of `9` for all other platforms.
-  </dd>
-  <dt><dfn dict-member for=OpusEncoderConfig>packetlossperc</dfn></dt>
-  <dd>
-    Configures the encoder's expected packet loss percentage. The valid range is
-    `0` to `100`.
-
-    NOTE: The packet loss percentage might be updated over the course of an
-    encoding, and it is recommended for User Agents to support these reconfigurations.
-  </dd>
-  <dt><dfn dict-member for=OpusEncoderConfig>useinbandfec</dfn></dt>
-  <dd>
-    Specifies whether the encoder provides Opus in-band Forward Error Correction
-    (FEC), as described by section 2.1.7. of [[RFC6716]].
-  </dd>
-  <dt><dfn dict-member for=OpusEncoderConfig>usedtx</dfn></dt>
-  <dd>
-    Specifies if the encoder uses Discontinuous Transmission (DTX), as described
-    by section 2.1.9. of [[RFC6716]].
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>complexity</dfn></dt>
   <dd>

--- a/pcm_codec_registration.src.html
+++ b/pcm_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/pcm_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-pcm-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for Linear PCM, the (1) fully qualified codec strings,

--- a/ulaw_codec_registration.src.html
+++ b/ulaw_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/ulaw_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-ulaw-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for u-law encoded PCM, the (1) fully qualified codec strings,

--- a/vorbis_codec_registration.src.html
+++ b/vorbis_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/vorbis_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-vorbis-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for Vorbis, the (1) fully qualified codec strings,

--- a/vp8_codec_registration.src.html
+++ b/vp8_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/vp8_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-vp8-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for VP8, the (1) fully qualified codec strings,

--- a/vp9_codec_registration.src.html
+++ b/vp9_codec_registration.src.html
@@ -7,9 +7,9 @@ Level: none
 Group: mediawg
 ED: https://w3c.github.io/webcodecs/vp9_codec_registration.html
 TR: https://www.w3.org/TR/webcodecs-vp9-codec-registration/
-Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 Editor: Paul Adenot, w3cid 62410, Mozilla https://www.mozilla.org/
 Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.microsoft.com/
+Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for VP9, the (1) fully qualified codec strings,


### PR DESCRIPTION
Here's a PR to note @chcunningham is now a former editor of the WebCodecs specs.     Chris, if you're watching, please LGTM.

I also took the liberty of removing some duplicate text in the opus codec registration that was causing bikeshed to complain about duplicate definitions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mfoltzgoogle/webcodecs/pull/610.html" title="Last updated on Nov 16, 2022, 10:09 PM UTC (2079174)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/610/71b75a6...mfoltzgoogle:2079174.html" title="Last updated on Nov 16, 2022, 10:09 PM UTC (2079174)">Diff</a>