### PR TITLE
Update WGSL of renderer_webgpu.js

### DIFF
--- a/samples/video-decode-display/renderer_webgpu.js
+++ b/samples/video-decode-display/renderer_webgpu.js
@@ -52,7 +52,7 @@ class WebGPURenderer {
     
     @fragment
     fn frag_main(@location(0) uv : vec2<f32>) -> @location(0) vec4<f32> {
-      return textureSampleLevel(myTexture, mySampler, uv);
+      return textureSampleBaseClampToEdge(myTexture, mySampler, uv);
     }
   `;
 


### PR DESCRIPTION
This `textureSampleLevel()` overload was moved to a new `textureSampleBaseClampToEdge()` builtin