### PR TITLE
Drop local custom definitions where possible

### DIFF
--- a/aac_codec_registration.src.html
+++ b/aac_codec_registration.src.html
@@ -13,10 +13,10 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for AAC, the (1) fully qualified codec strings, (2) the
-    codec-specific {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=]
-    bytes, (3) the {{AudioDecoderConfig.description}} bytes, (4) the values of
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=], and (5) the
-    codec-specific extensions to {{AudioEncoderConfig}}
+    codec-specific {{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}}
+    bytes, (3) the {{AudioDecoderConfig/description|AudioDecoderConfig.description}}
+    bytes, (4) the values of {{EncodedAudioChunk}} {{EncodedAudioChunk/[[type]]}},
+    and (5) the codec-specific extensions to {{AudioEncoderConfig}}
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -30,23 +30,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
 !Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
-</pre>
-
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
-        text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
-        text: AudioDecoderConfig.numberOfChannels; url: dom-audiodecoderconfig-numberofchannels
-    type: dfn
-        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
-        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
-        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
-    type: interface
-        text: EncodedAudioChunk; url: encodedaudiochunk
-    type: dictionary
-        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
-        text: AudioEncoderConfig; url: dictdef-audioencoderconfig
 </pre>
 
 <pre class='biblio'>
@@ -76,32 +59,32 @@ EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================
 
 If the bitstream is in {{AacBitstreamFormat/adts}} format, the
-[=EncodedAudioChunk/[[internal data]]=] of {{EncodedAudioChunk}}s are expected
+{{EncodedAudioChunk/[[internal data]]}} of {{EncodedAudioChunk}}s are expected
 to be an ADTS frame, as described in section 1.A.3.2 of [[iso14496-3]].
 
 If the bitstream is in {{AacBitstreamFormat/aac}} format, the
-[=EncodedAudioChunk/[[internal data]]=] of {{EncodedAudioChunk}}s are expected
+{{EncodedAudioChunk/[[internal data]]}} of {{EncodedAudioChunk}}s are expected
 to be a raw AAC frame (syntax element `raw_data_block()`), as described in
 section 4.4.2.1 of [[iso14496-3]].
 
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-If {{AudioDecoderConfig.description}} is present, it is assumed to a
+If {{AudioDecoderConfig/description}} is present, it is assumed to a
 `AudioSpecificConfig` as defined in [[iso14496-3]] section 1.6.2.1, Table 1.15,
 and the bitstream is assumed to be in {{AacBitstreamFormat/aac}}.
 
-If the {{AudioDecoderConfig.description}} is not present, the bitstream is
+If the {{AudioDecoderConfig/description}} is not present, the bitstream is
 assumed to be in {{AacBitstreamFormat/adts}} format.
 
-The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.numberOfChannels}}
+The {{AudioDecoderConfig/sampleRate}} and {{AudioDecoderConfig/numberOfChannels}}
 members are ignored.
 
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================
 
-The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
-AAC is always "[=EncodedAudioChunkType/key=]".
+The {{EncodedAudioChunk/[[type]]}} for an {{EncodedAudioChunk}} containing
+AAC is always "{{EncodedAudioChunkType/key}}".
 
 NOTE: Once the initialization has succeeded, any AAC packet can be decoded at
     any time without error, but this might not result in the expected audio
@@ -161,12 +144,12 @@ NOTE: Once the initialization has succeeded, any AAC packet can be decoded at
       <dt><dfn enum-value for=AacBitstreamFormat>aac</dfn></dt>
       <dd>
         The metadata of the encoded audio stream are provided at configuration via
-        {{AudioDecoderConfig.description}}.
+        {{AudioDecoderConfig/description|AudioDecoderConfig.description}}.
       </dd>
       <dt><dfn enum-value for=AacBitstreamFormat>adts</dfn></dt>
       <dd>
         The metadata of the encoded audio stream are provided in each ADTS frame,
-        and therefore no {{AudioDecoderConfig.description}} is necessary.
+        and therefore no {{AudioDecoderConfig/description|AudioDecoderConfig.description}} is necessary.
     </dl>
 
 Privacy Considerations {#privacy-considerations}

--- a/alaw_codec_registration.src.html
+++ b/alaw_codec_registration.src.html
@@ -14,9 +14,9 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for A-law encoded PCM, the (1) fully qualified codec strings,
     (2) the codec-specific {{EncodedAudioChunk}}
-    [=EncodedAudioChunk/[[internal data]]=] bytes, (3) the
-    {{AudioDecoderConfig.description}}, and (4) the values of
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+    {{EncodedAudioChunk/[[internal data]]}} bytes, (3) the
+    {{AudioDecoderConfig/description|AudioDecoderConfig.description}},
+    and (4) the values of {{EncodedAudioChunk}} {{EncodedAudioChunk/[[type]]}}.
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -30,21 +30,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
 !Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
-</pre>
-
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
-    type: dfn
-        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
-        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
-        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
-    type: interface
-        text: EncodedAudioChunk; url: encodedaudiochunk
-    type: dictionary
-        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
-        text: AudioEncoderConfig; url: dictdef-audioencoderconfig
 </pre>
 
 <pre class='biblio'>
@@ -66,21 +51,21 @@ The codec string is `"alaw"`.
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================
 
-{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
+{{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}} is expected to be
 a sequence of bytes of arbitrary length, where each byte is an A-law
 encoded PCM sample as defined by Tables 1a and 1b in [[ITU-G.711]].
 
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-An {{AudioDecoderConfig.description}} is expected to be omitted from the
+The {{AudioDecoderConfig/description}} is expected to be omitted from the
 {{AudioDecoderConfig}}.
 
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================
 
-The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
-A-law PCM is always "[=EncodedAudioChunkType/key=]".
+The {{EncodedAudioChunk/[[type]]}} for an {{EncodedAudioChunk}} containing
+A-law PCM is always "{{EncodedAudioChunkType/key}}".
 
 Privacy Considerations {#privacy-considerations}
 ==========================================================================

--- a/av1_codec_registration.src.html
+++ b/av1_codec_registration.src.html
@@ -14,9 +14,9 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for AV1, the (1) fully qualified codec strings,
     (2) the codec-specific {{EncodedVideoChunk}}
-    [=EncodedVideoChunk/[[internal data]]=] bytes, (3) the
-    {{VideoDecoderConfig.description}} bytes, and (4) the values of
-    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=].
+    {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the
+    {{VideoDecoderConfig/description|VideoDecoderConfig.description}} bytes, and
+    (4) the values of {{EncodedVideoChunk}} {{EncodedVideoChunk/[[type]]}}.
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -30,24 +30,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
 !Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
-</pre>
-
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: EncodedVideoChunkMetadata.decoderConfig; url: dom-encodedvideochunkmetadata-decoderconfig
-        for: EncodedVideoChunkType; text: key; url: dom-encodedvideochunktype-key
-        text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
-    type: dfn
-        for: EncodedVideoChunk; text: [[internal data]]; url: dom-encodedvideochunk-internal-data-slot
-        for: EncodedVideoChunk; text: [[type]]; url: dom-encodedvideochunk-type-slot
-        for: VideoEncoder; text: [[output callback]]; url: dom-videoencoder-output-callback-slot
-    type: interface
-        text: EncodedVideoChunk; url: encodedvideochunk
-        text: VideoEncoder; url: videoencoder
-    type: dictionary
-        text: VideoEncoderConfig; url: dictdef-videoencoderconfig
-        text: VideoDecoderConfig; url: dictdef-videodecoderconfig
 </pre>
 
 <pre class='biblio'>
@@ -74,19 +56,19 @@ suffix as described in Section 5 of [[AV1-ISOBMFF]].
 EncodedVideoChunk data {#encodedvideochunk-data}
 ================================================
 
-{{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] is expected to be
+{{EncodedVideoChunk}} {{EncodedVideoChunk/[[internal data]]}} is expected to be
 data compliant to the "low-overhead bitstream format" as described in Section 5
 of [[AV1]].
 
 VideoDecoderConfig description {#videodecoderconfig-description}
 ================================================================
 
-{{VideoDecoderConfig.description}} is not used for this codec.
+{{VideoDecoderConfig/description}} is not used for this codec.
 
 EncodedVideoChunk type {#encodedvideochunk-type}
 ================================================
 
-If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
+If an {{EncodedVideoChunk}}'s {{EncodedVideoChunk/[[type]]}} is
 {{EncodedVideoChunkType/key}}, then the {{EncodedVideoChunk}} is expected to
 contain a frame with a `frame_type` of `KEY_FRAME` as defined in Section
 6.8.2 of [[AV1]].

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -14,10 +14,10 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for AVC (H.264), the (1) fully qualified codec strings,
     (2) the codec-specific {{EncodedVideoChunk}}
-    [=EncodedVideoChunk/[[internal data]]=] bytes, (3) the
-    {{VideoDecoderConfig.description}} bytes, (4) the values of
-    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=], and (5) the
-    codec-specific extensions to {{VideoEncoderConfig}}
+    {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the
+    {{VideoDecoderConfig/description|VideoDecoderConfig.description}} bytes,
+    (4) the values of {{EncodedVideoChunk}} {{EncodedVideoChunk/[[type]]}},
+    and (5) the codec-specific extensions to {{VideoEncoderConfig}}
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -31,24 +31,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
 !Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
-</pre>
-
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: EncodedVideoChunkMetadata.decoderConfig; url: dom-encodedvideochunkmetadata-decoderconfig
-        for: EncodedVideoChunkType; text: key; url: dom-encodedvideochunktype-key
-        text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
-    type: dfn
-        for: EncodedVideoChunk; text: [[internal data]]; url: dom-encodedvideochunk-internal-data-slot
-        for: EncodedVideoChunk; text: [[type]]; url: dom-encodedvideochunk-type-slot
-        for: VideoEncoder; text: [[output callback]]; url: dom-videoencoder-output-callback-slot
-    type: interface
-        text: EncodedVideoChunk; url: encodedvideochunk
-        text: VideoEncoder; url: videoencoder
-    type: dictionary
-        text: VideoEncoderConfig; url: dictdef-videoencoderconfig
-        text: VideoDecoderConfig; url: dictdef-videodecoderconfig
 </pre>
 
 <pre class='biblio'>
@@ -78,26 +60,26 @@ characters as described respectively in Section 3.4 of [[rfc6381]] and Section
 EncodedVideoChunk data {#encodedvideochunk-data}
 ================================================
 
-{{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] is expected to be
+{{EncodedVideoChunk}} {{EncodedVideoChunk/[[internal data]]}} is expected to be
 an access unit as defined in [[ITU-T-REC-H.264]] section 7.4.1.2.
 
 NOTE: An access unit contains exactly one primary coded picture.
 
 If the bitstream is in {{AvcBitstreamFormat/avc}} format,
-[=EncodedVideoChunk/[[internal data]]=] is assumed to be in canonical format, as
+{{EncodedVideoChunk/[[internal data]]}} is assumed to be in canonical format, as
 defined in [[iso14496-15]] section 5.3.2.
 
 If the bitstream is in {{AvcBitstreamFormat/annexb}} format,
-[=EncodedVideoChunk/[[internal data]]=] is assumed to be in in Annex B format,
+{{EncodedVideoChunk/[[internal data]]}} is assumed to be in in Annex B format,
 as defined in [[ITU-T-REC-H.264]] Annex B.
 
-NOTE: Since [=EncodedVideoChunk/[[internal data]]=] is inherently byte-aligned,
+NOTE: Since {{EncodedVideoChunk/[[internal data]]}} is inherently byte-aligned,
     implementations are not required to recover byte-alignment.
 
 VideoDecoderConfig description {#videodecoderconfig-description}
 ================================================================
 
-If the {{VideoDecoderConfig.description}} is present, it is assumed to be an
+If the {{VideoDecoderConfig/description}} is present, it is assumed to be an
 `AVCDecoderConfigurationRecord`, as defined by [[iso14496-15]], section
 5.3.3.1, and the bitstream is assumed to be in {{AvcBitstreamFormat/avc}}
 format.
@@ -105,7 +87,7 @@ format.
 NOTE: This format is commonly used in .MP4 files, where the player generally
     has random access to the media data.
 
-If the {{VideoDecoderConfig.description}} is not present, the bitstream is
+If the {{VideoDecoderConfig/description}} is not present, the bitstream is
 assumed to be in {{AvcBitstreamFormat/annexb}} format.
 
 NOTE: "annexb" format is described in greater detail by [[ITU-T-REC-H.264]],
@@ -116,16 +98,17 @@ NOTE: "annexb" format is described in greater detail by [[ITU-T-REC-H.264]],
 EncodedVideoChunk type {#encodedvideochunk-type}
 ================================================
 
-If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
+If an {{EncodedVideoChunk}}'s {{EncodedVideoChunk/[[type]]}} is
 {{EncodedVideoChunkType/key}}, and the bitstream is in
 {{AvcBitstreamFormat/avc}} format, then the {{EncodedVideoChunk}} is expected to
 contain a primary coded picture that is an instantaneous decoding refresh (IDR)
 picture.
 
 NOTE: If the bitstream is in {{AvcBitstreamFormat/avc}} format, parameter sets
-    necessary for decoding are included in {{VideoDecoderConfig.description}}.
+    necessary for decoding are included in
+    {{VideoDecoderConfig/description|VideoDecoderConfig.description}}.
 
-If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
+If an {{EncodedVideoChunk}}'s {{EncodedVideoChunk/[[type]]}} is
 {{EncodedVideoChunkType/key}}, and the bitstream is in
 {{AvcBitstreamFormat/annexb}} format, then the {{EncodedVideoChunk}} is expected
 to contain both a primary coded picture that is an instantaneous decoding
@@ -195,9 +178,9 @@ mechanisms for packaging the bitstream.
   <dt><dfn enum-value for=AvcBitstreamFormat>avc</dfn></dt>
   <dd>
     SPS and PPS data are not included in the bitstream and are instead emitted
-    via the [=VideoEncoder/[[output callback]]=] as the
-    {{VideoDecoderConfig.description}} of the
-    {{EncodedVideoChunkMetadata.decoderConfig}}.
+    via the {{VideoEncoder/[[output callback]]}} as the
+    {{VideoDecoderConfig/description|VideoDecoderConfig.description}} of the
+    {{EncodedVideoChunkMetadata/decoderConfig|EncodedVideoChunkMetadata.decoderConfig}}.
 
     NOTE: This format is described in greater detail by [[iso14496-15]],
         section 5.3. This format is commonly used in .MP4 files, where the

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -34,23 +34,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
 </pre>
 
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
-        text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
-    type: dfn
-        for: EncodedVideoChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
-    type: interface
-        text: EncodedAudioChunk; url: encodedaudiochunk
-        text: EncodedVideoChunk; url: encodedvideochunk
-    type: dictionary
-        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
-        text: AudioEncoderConfig; url: dictdef-audioencoderconfig
-        text: VideoDecoderConfig; url: dictdef-videodecoderconfig
-        text: VideoEncoderConfig; url: dictdef-videoencoderconfig
-</pre>
-
 
 Organization {#organization}
 ============================
@@ -78,7 +61,7 @@ Registration Entry Requirements {#registration-entry-requirements}
     2. {{EncodedAudioChunk}} or {{EncodedVideoChunk}} internal data
     3. {{AudioDecoderConfig}} or {{VideoDecoderConfig}} description bytes
     4. Expectations for {{EncodedAudioChunk}} or {{EncodedVideoChunk}}
-        [=EncodedVideoChunk/[[type]]=]
+        {{EncodedVideoChunk/[[type]]}}
 3. Where applicable, a registration specification may include a section
     describing extensions to {{VideoEncoderConfig}} or {{AudioEncoderConfig}}
     dictionaries.

--- a/flac_codec_registration.src.html
+++ b/flac_codec_registration.src.html
@@ -14,10 +14,10 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for FLAC, the (1) fully qualified codec strings,
     (2) the codec-specific {{EncodedAudioChunk}}
-    [=EncodedAudioChunk/[[internal data]]=] bytes, (3) the
-    {{AudioDecoderConfig.description}} bytes, and (4) the values of
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=], and (5) the
-    codec-specific extensions to {{AudioEncoderConfig}}.
+    {{EncodedAudioChunk/[[internal data]]}} bytes, (3) the
+    {{AudioDecoderConfig/description|AudioDecoderConfig.description}} bytes,
+    (4) the values of {{EncodedAudioChunk}} {{EncodedAudioChunk/[[type]]}},
+    and (5) the codec-specific extensions to {{AudioEncoderConfig}}.
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -31,23 +31,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
 !Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
-</pre>
-
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
-        text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
-        text: AudioDecoderConfig.numberOfChannels; url: dom-audiodecoderconfig-numberofchannels
-    type: dfn
-        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
-        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
-        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
-    type: interface
-        text: EncodedAudioChunk; url: encodedaudiochunk
-    type: dictionary
-        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
-        text: AudioEncoderConfig; url: dictdef-audioencoderconfig
 </pre>
 
 <pre class='biblio'>
@@ -68,21 +51,21 @@ The codec string is `"flac"`.
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================
 
-{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
+{{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}} is expected to be
 a "FRAME" as described in [[FLAC]].
 
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-{{AudioDecoderConfig.description}} is required, and has to be the following:
+{{AudioDecoderConfig/description}} is required, and has to be the following:
 
 - The bytes `0x66 0x4C 0x61 0x43` ("`fLaC`" in ASCII)
 - A `metadata block` (called the STREAMINFO block) as described in section 7 of [[FLAC]]
 - Optionaly other metadata blocks, that are not used by the specification
 
-The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.numberOfChannels}}
+The {{AudioDecoderConfig/sampleRate}} and {{AudioDecoderConfig/numberOfChannels}}
 members are overridden by what the decoder finds in the
-{{AudioDecoderConfig.description}}.
+{{AudioDecoderConfig/description}}.
 
 NOTE: This corresponds to the beginning of a FLAC bitstream, before the audio
     frames.
@@ -90,8 +73,8 @@ NOTE: This corresponds to the beginning of a FLAC bitstream, before the audio
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================
 
-The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
-FLAC is always "[=EncodedAudioChunkType/key=]".
+The {{EncodedAudioChunk/[[type]]}} for an {{EncodedAudioChunk}} containing
+FLAC is always "{{EncodedAudioChunkType/key}}".
 
 NOTE: Once the initialization has succeeded, any FLAC packet can be decoded at
     any time without error, but this might not result in the expected audio output.
@@ -129,7 +112,7 @@ dictionary FlacEncoderConfig {
 
 To check if an {{FlacEncoderConfig}} is valid, run these steps:
 1. If {{FlacEncoderConfig/blockSize}} is not a valid block size,
-	which is described section 5.1 of [[FLAC]], return `false`.
+    which is described section 5.1 of [[FLAC]], return `false`.
 1. If {{FlacEncoderConfig/compressLevel}} is specified and not within the range of
     `0` (fastest, least compression) and `8` (slowest, most compression) inclusively, return `false`.
 2. Return `true`.
@@ -138,8 +121,8 @@ To check if an {{FlacEncoderConfig}} is valid, run these steps:
   <dt><dfn dict-member for=FlacEncoderConfig>blockSize</dfn></dt>
   <dd>
     Configures the number of samples to use per frame, of output {{EncodedAudioChunk}}s.
-	
-	NOTE: Use 0 to let the encoder estimate a blocksize by default.
+    
+    NOTE: Use 0 to let the encoder estimate a blocksize by default.
   </dd>
   
   <dt><dfn dict-member for=FlacEncoderConfig>compressLevel</dfn></dt>

--- a/hevc_codec_registration.src.html
+++ b/hevc_codec_registration.src.html
@@ -14,10 +14,10 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for HEVC (H.265), the (1) fully qualified codec strings,
     (2) the codec-specific {{EncodedVideoChunk}}
-    [=EncodedVideoChunk/[[internal data]]=] bytes, (3) the
-    {{VideoDecoderConfig.description}} bytes, (4) the values of
-    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=], and (5) the
-    codec-specific extensions to {{VideoEncoderConfig}}
+    {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the
+    {{VideoDecoderConfig/description|VideoDecoderConfig.description}} bytes,
+    (4) the values of {{EncodedVideoChunk}} {{EncodedVideoChunk/[[type]]}}, and
+    (5) the codec-specific extensions to {{VideoEncoderConfig}}
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -33,23 +33,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
 </pre>
 
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: EncodedVideoChunkMetadata.decoderConfig; url: dom-encodedvideochunkmetadata-decoderconfig
-        for: EncodedVideoChunkType; text: key; url: dom-encodedvideochunktype-key
-        text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
-    type: dfn
-        for: EncodedVideoChunk; text: [[internal data]]; url: dom-encodedvideochunk-internal-data-slot
-        for: EncodedVideoChunk; text: [[type]]; url: dom-encodedvideochunk-type-slot
-        for: VideoEncoder; text: [[output callback]]; url: dom-videoencoder-output-callback-slot
-    type: interface
-        text: EncodedVideoChunk; url: encodedvideochunk
-        text: VideoEncoder; url: videoencoder
-    type: dictionary
-        text: VideoEncoderConfig; url: dictdef-videoencoderconfig
-        text: VideoDecoderConfig; url: dictdef-videodecoderconfig
-</pre>
 
 <pre class='biblio'>
 {
@@ -77,26 +60,26 @@ four dot-separated fields as described in Section E.3 of [[iso14496-15]].
 EncodedVideoChunk data {#encodedvideochunk-data}
 ================================================
 
-{{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] is expected to be
+{{EncodedVideoChunk}} {{EncodedVideoChunk/[[internal data]]}} is expected to be
 an access unit as defined in [[ITU-T-REC-H.265]] section 7.4.2.4.
 
 NOTE: An access unit contains exactly one base layer coded picture.
 
 If the bitstream is in {{HevcBitstreamFormat/hevc}} format,
-[=EncodedVideoChunk/[[internal data]]=] is assumed to be in canonical format, as
+{{EncodedVideoChunk/[[internal data]]}} is assumed to be in canonical format, as
 defined in [[iso14496-15]] section 8.3.2.
 
 If the bitstream is in {{HevcBitstreamFormat/annexb}} format,
-[=EncodedVideoChunk/[[internal data]]=] is assumed to be in Annex B format,
+{{EncodedVideoChunk/[[internal data]]}} is assumed to be in Annex B format,
 as defined in [[ITU-T-REC-H.265]] Annex B.
 
-NOTE: Since [=EncodedVideoChunk/[[internal data]]=] is inherently byte-aligned,
+NOTE: Since {{EncodedVideoChunk/[[internal data]]}} is inherently byte-aligned,
     implementations are not required to recover byte-alignment.
 
 VideoDecoderConfig description {#videodecoderconfig-description}
 ================================================================
 
-If the {{VideoDecoderConfig.description}} is present, it is assumed to be an
+If the {{VideoDecoderConfig/description}} is present, it is assumed to be an
 `HEVCDecoderConfigurationRecord`, as defined by [[iso14496-15]], section
 8.3.3.1, and the bitstream is assumed to be in {{HevcBitstreamFormat/hevc}}
 format.
@@ -104,7 +87,7 @@ format.
 NOTE: This format is commonly used in .MP4 files, where the player generally
     has random access to the media data.
 
-If the {{VideoDecoderConfig.description}} is not present, the bitstream is
+If the {{VideoDecoderConfig/description}} is not present, the bitstream is
 assumed to be in {{HevcBitstreamFormat/annexb}} format.
 
 NOTE: "annexb" format is described in greater detail by [[ITU-T-REC-H.265]],
@@ -115,16 +98,17 @@ NOTE: "annexb" format is described in greater detail by [[ITU-T-REC-H.265]],
 EncodedVideoChunk type {#encodedvideochunk-type}
 ================================================
 
-If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
+If an {{EncodedVideoChunk}}'s {{EncodedVideoChunk/[[type]]}} is
 {{EncodedVideoChunkType/key}}, and the bitstream is in
 {{HevcBitstreamFormat/hevc}} format, then the {{EncodedVideoChunk}} is expected
 to contain a base layer primary coded picture that is an instantaneous decoding
 refresh (IDR), clean random access (CRA), or broken link access (BLA) picture.
 
 NOTE: If the bitstream is in {{HevcBitstreamFormat/hevc}} format, parameter sets
-    necessary for decoding are included in {{VideoDecoderConfig.description}}.
+    necessary for decoding are included in
+    {{VideoDecoderConfig/description|VideoDecoderConfig.description}}.
 
-If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
+If an {{EncodedVideoChunk}}'s {{EncodedVideoChunk/[[type]]}} is
 {{EncodedVideoChunkType/key}}, and the bitstream is in
 {{HevcBitstreamFormat/annexb}} format, then the {{EncodedVideoChunk}} is
 expected to contain both a base layer coded picture that is an instantaneous
@@ -195,9 +179,9 @@ mechanisms for packaging the bitstream.
   <dt><dfn enum-value for=AvcBitstreamFormat>hevc</dfn></dt>
   <dd>
     Parameter sets are not included in the bitstream and are instead emitted
-    via the [=VideoEncoder/[[output callback]]=] as the
-    {{VideoDecoderConfig.description}} of the
-    {{EncodedVideoChunkMetadata.decoderConfig}}.
+    via the {{VideoEncoder/[[output callback]]}} as the
+    {{VideoDecoderConfig/description}} of the
+    {{EncodedVideoChunkMetadata/decoderConfig|EncodedVideoChunkMetadata.decoderConfig}}.
 
     NOTE: This format is described in greater detail by [[iso14496-15]],
         section 8.3. This format is commonly used in .MP4 files, where the

--- a/index.src.html
+++ b/index.src.html
@@ -28,74 +28,25 @@ Markup Shorthands:css no, markdown yes, dfn yes
 </pre>
 
 <pre class=link-defaults>
-spec:webidl; type:interface; text:Promise
 spec:html; type:attribute; text:hidden
+spec:infra; type:dfn; text:list
+spec:infra; type:dfn; text:enqueue
 </pre>
 
 <pre class='anchors'>
-spec: media-source; urlPrefix: https://www.w3.org/TR/media-source/
-    type: method
-        for: MediaSource; text: isTypeSupported(); url: #dom-mediasource-istypesupported
-
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
-    for: HTMLMediaElement;
-        type: method; text: canPlayType(); url: #dom-navigator-canplaytype
-    for: PlatformObject;
-        type: attribute; text: [[Detached]]; url: structured-data.html#detached
+    type: typedef; text: CanvasImageSource; url: canvas.html#canvasimagesource
+    for: CanvasDrawImage;
+        type: method; text: drawImage(); url: canvas.html#dom-context-2d-drawimage
     for: ImageBitmap;
-        type: attribute; text: resizeWidth; url:#dom-imagebitmapoptions-resizewidth
-        type: attribute; text: resizeHeight; url:#dom-imagebitmapoptions-resizeheight
-        type: dfn; text: cropped to the source rectangle with formatting; url: imagebitmap-and-animations.html#cropped-to-the-source-rectangle-with-formatting
         type: dfn; text: bitmap data; url: imagebitmap-and-animations.html#concept-imagebitmap-bitmap-data
     for: Canvas;
         type: dfn; text: Check the usability of the image argument; url: canvas.html#check-the-usability-of-the-image-argument
-    for: origin;
-        type: dfn; text: origin; url: origin.html#concept-origin
     for: webappapis;
-        type: dfn; text: global object; url: webappapis.html#global-object
         type: dfn; text: entry settings object; url: webappapis.html#entry-settings-object
     for: media;
         type: dfn; text: current playback position; url: media.html#current-playback-position
     type: dfn; text: live; url: infrastructure.html#live
-
-spec: mediacapture-streams; urlPrefix: https://www.w3.org/TR/mediacapture-streams/
-    for: mediaDevices;
-        type: method; text: getUserMedia(); url: #dom-mediadevices-getusermedia
-
-spec: mediacapture-screen-share; urlPrefix: https://w3c.github.io/mediacapture-screen-share/
-    for: mediaDevices; type: method; text: getDisplayMedia(); url: #dom-mediadevices-getdisplaymedia
-
-spec: mediacapture-main; urlPrefix: https://w3c.github.io/mediacapture-main/
-    for:MediaStreamTrackState;
-        type: enum-value; text: live; url: #idl-def-MediaStreamTrackState.live
-        type: enum-value; text: ended; url: #idl-def-MediaStreamTrackState.ended
-
-spec: mimesniff; urlPrefix: https://mimesniff.spec.whatwg.org/#
-    type: dfn; text: MIME type; url: mime-type
-    type: dfn; text: valid MIME type string; url:valid-mime-type
-
-spec: infra; urlPrefix: https://infra.spec.whatwg.org/#
-    type: dfn; text: queue; url: queues
-    type: dfn; text: enqueuing; url: queue-enqueue;
-    type: dfn; text: dequeued; url: queue-dequeue;
-    type: dfn; text: empty; url: list-is-empty;
-    type: dfn; text: list; url: lists;
-
-spec: mediastream-recording; urlPrefix: https://www.w3.org/TR/mediastream-recording/#
-    type: interface; text: MediaRecorder; url: mediarecorder
-    type: interface; text: BitrateMode; url: bitratemode
-    for: BitrateMode;
-        type: enum-value; text: constant; url: dom-bitratemode-constant
-        type: enum-value; text: variable; url: dom-bitratemode-variable
-
-spec: media-capabilities; urlPrefix: https://w3c.github.io/media-capabilities/#
-    type: method; text: decodingInfo(); url: dom-mediacapabilities-decodinginfo
-    type: attribute; text: powerEfficient; url: dom-mediacapabilitiesinfo-powerefficient
-
-spec: css-images-3; urlPrefix: https://www.w3.org/TR/css-images-3/
-    type: dfn; text: natural dimensions; url: #natural-dimensions
-    type: dfn; text: natural width; url: #natural-width
-    type: dfn; text: natural height; url: #natural-height
 
 spec: webrtc-svc; urlPrefix: https://w3c.github.io/webrtc-svc/
     type: dfn; text: scalability mode identifier; url:#scalabilitymodes*
@@ -2539,9 +2490,9 @@ enum EncodedAudioChunkType {
         to the {{EncodedAudioChunk}} internal slot in |value| with the same name
         as the named field.
 
-NOTE: Since {{EncodedAudioChunk}}s are immutable, User Agents may choose to
-    implement serialization using a reference counting model similar to
-    [[#audiodata-transfer-serialization]].
+NOTE: <span class=allow-2119>Since {{EncodedAudioChunk}}s are immutable, User
+    Agents may choose to implement serialization using a reference counting
+    model similar to [[#audiodata-transfer-serialization]].</span>
 
 EncodedVideoChunk Interface{#encodedvideochunk-interface}
 -----------------------------------------------------------
@@ -2631,9 +2582,9 @@ enum EncodedVideoChunkType {
         to the {{EncodedVideoChunk}} internal slot in |value| with the same name
         as the named field.
 
-NOTE: Since {{EncodedVideoChunk}}s are immutable, User Agents may choose to
-    implement serialization using a reference counting model similar to
-    [[#videoframe-transfer-serialization]].
+NOTE: <span class=allow-2119>Since {{EncodedVideoChunk}}s are immutable, User
+    Agents may choose to implement serialization using a reference counting
+    model similar to [[#videoframe-transfer-serialization]].</span>
 
 
 Raw Media Interfaces {#raw-media-interfaces}
@@ -2684,8 +2635,9 @@ NOTE: When a [=media resource=] is no longer referenced by a
 
 This section is non-normative.
 
-{{AudioData}} and {{VideoFrame}} are both [=transferable objects|transferable=]
-and [=serializable objects|serializable=] objects. Their transfer and
+{{AudioData}} and {{VideoFrame}} are both
+[[HTML#transferable-objects|transferable]] and
+[[HTML#serializable-objects|serializable]] objects. Their transfer and
 serialization steps are defined in [[#audiodata-transfer-serialization]] and
 [[#videoframe-transfer-serialization]] respectively.
 
@@ -3351,9 +3303,9 @@ dictionary VideoFrameMetadata {
 1. [=Canvas/Check the usability of the image argument=]. If this throws an
     exception or returns <var ignore=''>bad</var>, then throw an
     {{InvalidStateError}} {{DOMException}}.
-2. If the [=origin/origin=] of |image|'s image data is not [=same origin=]
+2. If the [=/origin=] of |image|'s image data is not [=same origin=]
     with the [=webappapis/entry settings object=]'s
-    [=origin/origin=], then throw a {{SecurityError}}
+    [=/origin=], then throw a {{SecurityError}}
     {{DOMException}}.
 3. Let |frame| be a new {{VideoFrame}}.
 5. Switch on |image|:
@@ -5066,7 +5018,7 @@ interface ImageDecoder {
                 [=track update struct/track index=] is |trackIndex| and
                 [=track update struct/frame count=] is |latestFrameCount|.
             2. Append |change| to |tracksChanges|.
-    5. If |tracksChanges| is [=list/empty=], abort these steps.
+    5. If |tracksChanges| [=list/is empty=], abort these steps.
     6. [=Queue a task=] to perform the following steps:
         1. For each <var ignore=''>update</var> in |trackChanges|:
             1. Let |updateTrack| be the {{ImageTrack}} at position
@@ -5269,7 +5221,7 @@ run these steps:
 3. If |data| is of type {{BufferSource}}:
     1. If the result of running  IsDetachedBuffer (described in
         [[!ECMASCRIPT]]) on |data| is `false`, return `false`.
-    2. If |data| is [=empty=], return `false`.
+    2. If |data| [=list/is empty=], return `false`.
 4. If {{ImageDecoderInit/desiredWidth}} [=map/exists=] and
     {{ImageDecoderInit/desiredHeight}} does not exist, return `false`.
 5. If {{ImageDecoderInit/desiredHeight}} [=map/exists=] and
@@ -5560,7 +5512,7 @@ if it is:
 
     - An {{AudioDecoder}} or {{VideoDecoder}}, when there is, respectively, an
         [=active=] {{AudioEncoder}} or {{VideoEncoder}} in the same
-        [=webappapis/global object=].
+        [=/global object=].
 
         NOTE: This prevents prevents breaking long running transcoding tasks.
 

--- a/index.src.html
+++ b/index.src.html
@@ -35,9 +35,6 @@ spec:infra; type:dfn; text:enqueue
 
 <pre class='anchors'>
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
-    type: typedef; text: CanvasImageSource; url: canvas.html#canvasimagesource
-    for: CanvasDrawImage;
-        type: method; text: drawImage(); url: canvas.html#dom-context-2d-drawimage
     for: ImageBitmap;
         type: dfn; text: bitmap data; url: imagebitmap-and-animations.html#concept-imagebitmap-bitmap-data
     for: Canvas;

--- a/mp3_codec_registration.src.html
+++ b/mp3_codec_registration.src.html
@@ -13,9 +13,10 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for MP3, the (1) fully qualified codec strings, (2)
-    the {{AudioDecoderConfig.description}} bytes, (3) the codec-specific
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] bytes, and (4)
-    the values of {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+    the {{AudioDecoderConfig/description|AudioDecoderConfig.description}} bytes,
+    (3) the codec-specific {{EncodedAudioChunk}}
+    {{EncodedAudioChunk/[[internal data]]}} bytes, and (4)
+    the values of {{EncodedAudioChunk}} {{EncodedAudioChunk/[[type]]}}.
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -31,21 +32,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
 </pre>
 
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
-        text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
-        text: AudioDecoderConfig.numberOfChannels; url: dom-audiodecoderconfig-numberofchannels
-    type: dfn
-        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
-        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
-        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
-    type: interface
-        text: EncodedAudioChunk; url: encodedaudiochunk
-    type: dictionary
-        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
-</pre>
 
 <pre class='biblio'>
 {
@@ -72,23 +58,23 @@ This codec has multiple equivalent codec strings:
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================
 
-{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
+{{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}} is expected to be
 a "frame", as described in the section 2.4.2.2 of the [[MP3]] specification.
 
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-{{AudioDecoderConfig.description}} is not used for this codec.
+{{AudioDecoderConfig/description}} is not used for this codec.
 
-The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.numberOfChannels}}
+The {{AudioDecoderConfig/sampleRate}} and {{AudioDecoderConfig/numberOfChannels}}
 members are ignored.
 
 
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================
 
-The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
-mp3 is always "[=EncodedAudioChunkType/key=]".
+The {{EncodedAudioChunk/[[type]]}} for an {{EncodedAudioChunk}} containing
+mp3 is always "{{EncodedAudioChunkType/key}}".
 
 NOTE: Once the initialization has succeeded, any mp3 packet can be decoded at
     any time without error, but this might not result in the expected audio

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -13,10 +13,10 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for Opus, the (1) fully qualified codec strings, (2) the
-    codec-specific {{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=]
-    bytes, (3) the {{AudioDecoderConfig.description}} bytes, (4) the values of
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=], and (5) the
-    codec-specific extensions to {{AudioEncoderConfig}}
+    codec-specific {{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}}
+    bytes, (3) the {{AudioDecoderConfig/description|AudioDecoderConfig.description}}
+    bytes, (4) the values of {{EncodedAudioChunk}} {{EncodedAudioChunk/[[type]]}},
+    and (5) the codec-specific extensions to {{AudioEncoderConfig}}
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -32,22 +32,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
 </pre>
 
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
-    type: dfn
-        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
-        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
-        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
-    type: method
-        for: AudioDecoder; text: AudioDecoder.decode; url: dom-audiodecoder-decode
-    type: interface
-        text: EncodedAudioChunk; url: encodedaudiochunk
-    type: dictionary
-        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
-        text: AudioEncoderConfig; url: dictdef-audioencoderconfig
-</pre>
 
 <pre class='biblio'>
 {
@@ -87,20 +71,20 @@ If the bitstream is in {{OpusBitstreamFormat/ogg}} format,
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-{{AudioDecoderConfig.description}} can optionally set to an Identification
+{{AudioDecoderConfig/description}} can optionally set to an Identification
 Header, described in section 5.1 of [[OPUS-IN-OGG]].
 
-If an {{AudioDecoderConfig.description}} has been set, the bistream is assumed
+If a {{AudioDecoderConfig/description}} has been set, the bistream is assumed
 to be in {{OpusBitstreamFormat/ogg}} format.
 
-If an {{AudioDecoderConfig.description}} has not been set, the bitstream is
+If a {{AudioDecoderConfig/description}} has not been set, the bitstream is
 assumed to be in {{OpusBitstreamFormat/opus}} format.
 
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================
 
-The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
-Opus is always "[=EncodedAudioChunkType/key=]".
+The {{EncodedAudioChunk/[[type]]}} for an {{EncodedAudioChunk}} containing
+Opus is always "{{EncodedAudioChunkType/key}}".
 
 NOTE: Once the initialization has succeeded, any packet can be decoded at any
 time without error, but this might not result in the expected audio output.
@@ -209,7 +193,7 @@ encoded audio stream.
   <dt><dfn enum-value for=OpusBitstreamFormat>ogg</dfn></dt>
   <dd>
     The metadata of the encoded audio stream are provided at configuration via
-    {{AudioDecoderConfig.description}}.
+    {{AudioDecoderConfig/description|AudioDecoderConfig.description}}.
   </dd>
 </dl>
 

--- a/pcm_codec_registration.src.html
+++ b/pcm_codec_registration.src.html
@@ -14,9 +14,9 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for Linear PCM, the (1) fully qualified codec strings,
     (2) the codec-specific {{EncodedAudioChunk}}
-    [=EncodedAudioChunk/[[internal data]]=] bytes, (3) the
-    {{AudioDecoderConfig.description}}, and (4) the values of
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+    {{EncodedAudioChunk/[[internal data]]}} bytes, (3) the
+    {{AudioDecoderConfig/description|AudioDecoderConfig.description}}, and
+    (4) the values of {{EncodedAudioChunk}} {{EncodedAudioChunk/[[type]]}}.
 
     Linear PCM is the [[webcodecs#audio-sample-formats|raw audio format]] used
     in WebCodecs and does not require decoding. The motivation for registering
@@ -38,28 +38,8 @@ Markup Shorthands:css no, markdown yes, dfn yes
 
 <pre class='anchors'>
 spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
     type: dfn
-        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
-        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
-        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
-        text: sample; url: sample
         text: interleaved; url: interleaved
-        text: section on sample magnitude; url: audio-samples-magnitude
-    type: interface
-        text: EncodedAudioChunk; url: encodedaudiochunk
-        text: AudioData; url: audiodata-interface
-    type: dictionary
-        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
-        text: AudioEncoderConfig; url: dictdef-audioencoderconfig
-    type: enum
-        text: AudioSampleFormat; url: enumdef-audiosampleformat
-        text: u8; url: dom-audiosampleformat-u8
-        text: s16; url: dom-audiosampleformat-s16
-        text: s24; url: dom-audiosampleformat-s24
-        text: s32; url: dom-audiosampleformat-s32
-        text: f32; url: dom-audiosampleformat-f32
 </pre>
 
 
@@ -80,7 +60,7 @@ formats is as follows.
 NOTE: [[WEBCODECS]] does not define a 24-bit {{AudioSampleFormat}}. 24-bit
     samples are permitted within an {{EncodedAudioChunk}}, but such samples will
     be "decoded" in {{AudioData}} objects as either {{s32}} of {{f32}}. Please
-    see [[WEBCODECS]] [=section on sample magnitude=] for addtional details.
+    see [[WEBCODECS#audio-samples-magnitude]] for additional details.
 
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================
@@ -89,7 +69,7 @@ Linear pulse code modulation (linear PCM) describes a format where the audio
 values are sampled at a regular interval, and where the quantization levels
 between two successive values are linearly uniform.
 
-{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
+{{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}} is expected to be
 a sequence of bytes of arbitrary length, with a [=sample=] occuring every N
 bits, where N is defined by the codec string. For multichannel PCM, [=samples=]
 from different channels are [=interleaved=].
@@ -98,14 +78,14 @@ from different channels are [=interleaved=].
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-An {{AudioDecoderConfig.description}} is expected to be omitted from the
+The {{AudioDecoderConfig/description}} is expected to be omitted from the
 {{AudioDecoderConfig}}.
 
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================
 
-The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
-Linear PCM is always "[=EncodedAudioChunkType/key=]".
+The {{EncodedAudioChunk/[[type]]}} for an {{EncodedAudioChunk}} containing
+Linear PCM is always "{{EncodedAudioChunkType/key}}".
 
 Privacy Considerations {#privacy-considerations}
 ==========================================================================

--- a/ulaw_codec_registration.src.html
+++ b/ulaw_codec_registration.src.html
@@ -14,9 +14,9 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for u-law encoded PCM, the (1) fully qualified codec strings,
     (2) the codec-specific {{EncodedAudioChunk}}
-    [=EncodedAudioChunk/[[internal data]]=] bytes, (3) the
-    {{AudioDecoderConfig.description}} bytes, and (4) the values of
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+    {{EncodedAudioChunk/[[internal data]]}} bytes, (3) the
+    {{AudioDecoderConfig/description|AudioDecoderConfig.description}} bytes,
+    and (4) the values of {{EncodedAudioChunk}} {{EncodedAudioChunk/[[type]]}}.
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -30,21 +30,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
 !Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
-</pre>
-
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
-    type: dfn
-        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
-        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
-        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
-    type: interface
-        text: EncodedAudioChunk; url: encodedaudiochunk
-    type: dictionary
-        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
-        text: AudioEncoderConfig; url: dictdef-audioencoderconfig
 </pre>
 
 <pre class='biblio'>
@@ -66,21 +51,21 @@ The codec string is `"ulaw"`.
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================
 
-{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
+{{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}} is expected to be
 a sequence of bytes of arbitrary length, where each byte is a u-law
 encoded PCM sample as defined by Table 2a and 2b in [[ITU-G.711]].
 
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-An {{AudioDecoderConfig.description}} is expected to be omitted from the
+The {{AudioDecoderConfig/description}} is expected to be omitted from the
 {{AudioDecoderConfig}}.
 
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================
 
-The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
-u-law PCM is always "[=EncodedAudioChunkType/key=]".
+The {{EncodedAudioChunk/[[type]]}} for an {{EncodedAudioChunk}} containing
+u-law PCM is always "{{EncodedAudioChunkType/key}}".
 
 Privacy Considerations {#privacy-considerations}
 ==========================================================================

--- a/video_frame_metadata_registry.src.html
+++ b/video_frame_metadata_registry.src.html
@@ -20,13 +20,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
 </pre>
 
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: dictionary
-        text: VideoFrame; url: dictdef-videoframe
-        text: VideoFrameMetadata; url: dictdef-videoframemetadata
-</pre>
-
 
 Registration Entry Requirements {#registration-entry-requirements}
 ==================================================================

--- a/vorbis_codec_registration.src.html
+++ b/vorbis_codec_registration.src.html
@@ -14,9 +14,9 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for Vorbis, the (1) fully qualified codec strings,
     (2) the codec-specific {{EncodedAudioChunk}}
-    [=EncodedAudioChunk/[[internal data]]=] bytes, (3) the
-    {{AudioDecoderConfig.description}} bytes, and (4) the values of
-    {{EncodedAudioChunk}} [=EncodedAudioChunk/[[type]]=].
+    {{EncodedAudioChunk/[[internal data]]}} bytes, (3) the
+    {{AudioDecoderConfig/description|AudioDecoderConfig.description}} bytes,
+    and (4) the values of {{EncodedAudioChunk}} {{EncodedAudioChunk/[[type]]}}.
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -30,22 +30,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
 !Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
-</pre>
-
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: AudioDecoderConfig.description; url: dom-audiodecoderconfig-description
-        text: AudioDecoderConfig.sampleRate; url: dom-audiodecoderconfig-samplerate
-        text: AudioDecoderConfig.numberOfChannels; url: dom-audiodecoderconfig-numberofchannels
-    type: dfn
-        for: EncodedAudioChunkType; text: key; url: dom-encodedaudiochunktype-key
-        for: EncodedAudioChunk; text: [[internal data]]; url: dom-encodedaudiochunk-internal-data-slot
-        for: EncodedAudioChunk; text: [[type]]; url: dom-encodedaudiochunk-type-slot
-    type: interface
-        text: EncodedAudioChunk; url: encodedaudiochunk
-    type: dictionary
-        text: AudioDecoderConfig; url: dictdef-audiodecoderconfig
 </pre>
 
 <pre class='biblio'>
@@ -72,20 +56,20 @@ The codec string is `"vorbis"`.
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================
 
-{{EncodedAudioChunk}} [=EncodedAudioChunk/[[internal data]]=] is expected to be
+{{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}} is expected to be
 an "audio packet", as described in the section 4.3 of the [[VORBIS]] specification.
 
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-{{AudioDecoderConfig.description}} is required. It is assumed to be in Xiph
+The {{AudioDecoderConfig/description}} is required. It is assumed to be in Xiph
 extradata format, described in [[OGG-FRAMING]]. This format consists in the
 `page_segments` field, followed by the `segment_table` field, followed by the
 three Vorbis header packets, respectively the identification header, the comments
 header, and the setup header, in this order, as described in section 4.2 of
 [[VORBIS]].
 
-The {{AudioDecoderConfig.sampleRate}} and {{AudioDecoderConfig.numberOfChannels}}
+The {{AudioDecoderConfig/sampleRate}} and {{AudioDecoderConfig/numberOfChannels}}
 members are overridden by what the decoder finds in the identification header.
 
 NOTE: The comments header content is not used by [[WEBCODECS]].
@@ -93,8 +77,8 @@ NOTE: The comments header content is not used by [[WEBCODECS]].
 EncodedAudioChunk type {#encodedaudiochunk-type}
 ================================================
 
-The [=EncodedAudioChunk/[[type]]=] for an {{EncodedAudioChunk}} containing
-Vorbis is always "[=EncodedAudioChunkType/key=]".
+The {{EncodedAudioChunk/[[type]]}} for an {{EncodedAudioChunk}} containing
+Vorbis is always "{{EncodedAudioChunkType/key}}".
 
 NOTE: Once the initialization has succeeded, any Vorbis packet can be decoded at
 any time without error, but this might not result in the expected audio output.

--- a/vp8_codec_registration.src.html
+++ b/vp8_codec_registration.src.html
@@ -14,9 +14,9 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for VP8, the (1) fully qualified codec strings,
     (2) the codec-specific {{EncodedVideoChunk}}
-    [=EncodedVideoChunk/[[internal data]]=] bytes, (3) the
-    {{VideoDecoderConfig.description}} bytes, and (4) the values of
-    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=].
+    {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the
+    {{VideoDecoderConfig/description|VideoDecoderConfig.description}} bytes,
+    and (4) the values of {{EncodedVideoChunk}} {{EncodedVideoChunk/[[type]]}}.
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -30,24 +30,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
 !Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
-</pre>
-
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: EncodedVideoChunkMetadata.decoderConfig; url: dom-encodedvideochunkmetadata-decoderconfig
-        for: EncodedVideoChunkType; text: key; url: dom-encodedvideochunktype-key
-        text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
-    type: dfn
-        for: EncodedVideoChunk; text: [[internal data]]; url: dom-encodedvideochunk-internal-data-slot
-        for: EncodedVideoChunk; text: [[type]]; url: dom-encodedvideochunk-type-slot
-        for: VideoEncoder; text: [[output callback]]; url: dom-videoencoder-output-callback-slot
-    type: interface
-        text: EncodedVideoChunk; url: encodedvideochunk
-        text: VideoEncoder; url: videoencoder
-    type: dictionary
-        text: VideoEncoderConfig; url: dictdef-videoencoderconfig
-        text: VideoDecoderConfig; url: dictdef-videodecoderconfig
 </pre>
 
 <pre class='biblio'>
@@ -68,18 +50,18 @@ The codec string is `"vp8"`.
 EncodedVideoChunk data {#encodedvideochunk-data}
 ================================================
 
-{{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] is expected to be
+{{EncodedVideoChunk}} {{EncodedVideoChunk/[[internal data]]}} is expected to be
 a frame as described in Section 4 and Annex A of [[VP8]].
 
 VideoDecoderConfig description {#videodecoderconfig-description}
 ================================================================
 
-{{VideoDecoderConfig.description}} is not used for this codec.
+The {{VideoDecoderConfig/description}} is not used for this codec.
 
 EncodedVideoChunk type {#encodedvideochunk-type}
 ================================================
 
-If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
+If an {{EncodedVideoChunk}}'s {{EncodedVideoChunk/[[type]]}} is
 {{EncodedVideoChunkType/key}}, then the {{EncodedVideoChunk}} is expected to
 contain a frame where `key_frame` is true as defined in Section 19.1 of [[VP8]].
 

--- a/vp9_codec_registration.src.html
+++ b/vp9_codec_registration.src.html
@@ -14,9 +14,9 @@ Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.co
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     It describes, for VP9, the (1) fully qualified codec strings,
     (2) the codec-specific {{EncodedVideoChunk}}
-    [=EncodedVideoChunk/[[internal data]]=] bytes, (3) the
-    {{VideoDecoderConfig.description}} bytes, and (4) the values of
-    {{EncodedVideoChunk}} [=EncodedVideoChunk/[[type]]=].
+    {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the
+    {{VideoDecoderConfig/description|VideoDecoderConfig.description}} bytes,
+    and (4) the values of {{EncodedVideoChunk}} {{EncodedVideoChunk/[[type]]}}.
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -30,24 +30,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
 !Participate: <a href="https://github.com/w3c/webcodecs">Git Repository.</a>
 !Participate: <a href="https://github.com/w3c/webcodecs/issues/new">File an issue.</a>
 !Version History: <a href="https://github.com/w3c/webcodecs/commits">https://github.com/w3c/webcodecs/commits</a>
-</pre>
-
-<pre class='anchors'>
-spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
-    type: attribute
-        text: EncodedVideoChunkMetadata.decoderConfig; url: dom-encodedvideochunkmetadata-decoderconfig
-        for: EncodedVideoChunkType; text: key; url: dom-encodedvideochunktype-key
-        text: VideoDecoderConfig.description; url: dom-videodecoderconfig-description
-    type: dfn
-        for: EncodedVideoChunk; text: [[internal data]]; url: dom-encodedvideochunk-internal-data-slot
-        for: EncodedVideoChunk; text: [[type]]; url: dom-encodedvideochunk-type-slot
-        for: VideoEncoder; text: [[output callback]]; url: dom-videoencoder-output-callback-slot
-    type: interface
-        text: EncodedVideoChunk; url: encodedvideochunk
-        text: VideoEncoder; url: videoencoder
-    type: dictionary
-        text: VideoEncoderConfig; url: dictdef-videoencoderconfig
-        text: VideoDecoderConfig; url: dictdef-videodecoderconfig
 </pre>
 
 <pre class='biblio'>
@@ -74,18 +56,18 @@ suffix as described in the "Codecs Parameter String" Section of [[VP9-ISOBMFF]].
 EncodedVideoChunk data {#encodedvideochunk-data}
 ================================================
 
-{{EncodedVideoChunk}} [=EncodedVideoChunk/[[internal data]]=] is expected to be
+{{EncodedVideoChunk}} {{EncodedVideoChunk/[[internal data]]}} is expected to be
 a frame as described in Section 6 of [[VP9]].
 
 VideoDecoderConfig description {#videodecoderconfig-description}
 ================================================================
 
-{{VideoDecoderConfig.description}} is not used for this codec.
+The {{VideoDecoderConfig/description}} is not used for this codec.
 
 EncodedVideoChunk type {#encodedvideochunk-type}
 ================================================
 
-If an {{EncodedVideoChunk}}'s [=EncodedVideoChunk/[[type]]=] is
+If an {{EncodedVideoChunk}}'s {{EncodedVideoChunk/[[type]]}} is
 {{EncodedVideoChunkType/key}}, then the {{EncodedVideoChunk}} is expected to
 contain a frame with a `frame_type` of `KEY_FRAME` as defined in Section
 7.2 of [[VP9]].


### PR DESCRIPTION
Bikeshed now contains cross-reference anchors from Webref, which means it now knows about a number of "new" specifications, including WebCodecs, Media Capture specs, the Infra standard, etc. See announcement at: https://lists.w3.org/Archives/Public/spec-prod/2023JanMar/0004.html

In turn, this means that WebCodecs specs no longer need to list and maintain a local database of cross-references, except in rare cases (such as when a term is not exported by the referenced spec).

This update drops local definitions where ever possible, adjusting references in the prose as needed. A few definitions remain here and there to list external terms that are not exported, along with a couple of linking defaults in the WebCodecs spec.

<del>One temporary hiccup: the markup definitions of `CanvasImageSource` and `drawImage()` are slightly incorrect. Hence the need to keep a local reference entry for them in WebCodecs. To be removed once the HTML spec is fixed.</del> (Definitions now fixed in the HTML spec)

In codec registration specs, note that the form `{{VideoDecoderConfig/description|VideoDecoderConfig.description}}` is used to output `VideoDecoderConfig.description` (with the right link to the WebCodecs spec) when merely having `description` would be ambiguous.

This update also gets rid of a couple of build warnings that Bikeshed reported (use of RFC 2119 terms in informative notes, inconsistent use of spaces and tabs for indentation).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webcodecs/pull/625.html" title="Last updated on Jan 17, 2023, 1:23 PM UTC (83bd02d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/625/47b8051...tidoust:83bd02d.html" title="Last updated on Jan 17, 2023, 1:23 PM UTC (83bd02d)">Diff</a>