### PR TITLE
Fix memory layout of NV12 image example

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4268,7 +4268,7 @@ is its own [=equivalent opaque format=].
     planes of Chroma, denoted Y, U and V, and present in this order. It is also
     often refered to as Planar YUV 4:2:0.
 
-    The U an V planes are [=sub-sampled=] horizontaly and vertically by a
+    The U an V planes are [=sub-sampled=] horizontally and vertically by a
     [=factor=] of 2 compared to the Y plane.
 
     Each sample in this format is 8 bits.
@@ -4296,7 +4296,7 @@ is its own [=equivalent opaque format=].
     present in this order. It is also often refered to as Planar YUV 4:2:0 with
     an alpha channel.
 
-    The U an V planes are [=sub-sampled=] horizontaly and vertically by a
+    The U an V planes are [=sub-sampled=] horizontally and vertically by a
     [=factor=] of 2 compared to the Y and Alpha planes.
 
     Each sample in this format is 8 bits.
@@ -4325,7 +4325,7 @@ is its own [=equivalent opaque format=].
     planes of Chroma, denoted Y, U and V, and present in this order. It is also
     often refered to as Planar YUV 4:2:2.
 
-    The U an V planes are [=sub-sampled=] horizontaly by a [=factor=] of 2
+    The U an V planes are [=sub-sampled=] horizontally by a [=factor=] of 2
     compared to the Y plane, and not [=sub-sampled=] vertically.
 
     Each sample in this format is 8 bits.
@@ -4366,7 +4366,7 @@ is its own [=equivalent opaque format=].
     another plane for the two Chroma components. The two planes are present in
     this order, and are refered to as respectively the Y plane and the UV plane.
 
-    The U an V components are [=sub-sampled=] horizontaly and vertically by a
+    The U an V components are [=sub-sampled=] horizontally and vertically by a
     [=factor=] of 2 compared to the components in the Y planes.
 
     Each sample in this format is 8 bits.
@@ -4389,28 +4389,25 @@ is its own [=equivalent opaque format=].
     {{VideoFrame/visibleRect}}.{{DOMRectInit/y}}) MUST be even.
 
     <div class=example>
-    An image in the NV12 pixel format that is 16 pixels wide and 9 pixels tall
+    An image in the NV12 pixel format that is 16 pixels wide and 10 pixels tall
     will be arranged like so in memory:
 
     ```
-        YYYYYYYYYYYYYY
-        YYYYYYYYYYYYYY
-        YYYYYYYYYYYYYY
-        YYYYYYYYYYYYYY
-        YYYYYYYYYYYYYY
-        YYYYYYYYYYYYYY
-        YYYYYYYYYYYYYY
-        YYYYYYYYYYYYYY
-        YYYYYYYYYYYYYY
-        UVUVUVUVUVUVUV
-        UVUVUVUVUVUVUV
-        UVUVUVUVUVUVUV
-        UVUVUVUVUVUVUV
-        UVUVUVUVUVUVUV
-        UVUVUVUVUVUVUV
-        UVUVUVUVUVUVUV
-        UVUVUVUVUVUVUV
-        UVUVUVUVUVUVUV
+        YYYYYYYYYYYYYYYY
+        YYYYYYYYYYYYYYYY
+        YYYYYYYYYYYYYYYY
+        YYYYYYYYYYYYYYYY
+        YYYYYYYYYYYYYYYY
+        YYYYYYYYYYYYYYYY
+        YYYYYYYYYYYYYYYY
+        YYYYYYYYYYYYYYYY
+        YYYYYYYYYYYYYYYY
+        YYYYYYYYYYYYYYYY
+        UVUVUVUVUVUVUVUV
+        UVUVUVUVUVUVUVUV
+        UVUVUVUVUVUVUVUV
+        UVUVUVUVUVUVUVUV
+        UVUVUVUVUVUVUVUV
     ```
 
     All samples being linear in memory.


### PR DESCRIPTION
According to the text, which I hope I read correctly:
- The coded width and coded height must be even. So image cannot be 16x9. This update makes it 16x10.
- There should be one Y byte per pixel, so 16x10 Y bytes (example only had 14 bytes per row).
- The U and V components are sub-sampled horizontally and vertically by a factor of 2, and interleaved, so there should 16x10/4 = 40 UV blocks (example only sub-sampled horizontally).

This update also fixes occurrences of "horizontaly".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webcodecs/pull/630.html" title="Last updated on Jan 24, 2023, 2:37 PM UTC (6728d4e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/630/47b8051...tidoust:6728d4e.html" title="Last updated on Jan 24, 2023, 2:37 PM UTC (6728d4e)">Diff</a>