### PR TITLE
Introducing a codec specific 'quantizer' mode for VideoEncoder

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2073,7 +2073,7 @@ dictionary VideoEncoderConfig {
   HardwareAcceleration hardwareAcceleration = "no-preference";
   AlphaOption alpha = "discard";
   DOMString scalabilityMode;
-  BitrateMode bitrateMode = "variable";
+  VideoEncoderBitrateMode bitrateMode = "variable";
   LatencyMode latencyMode = "quality";
 };
 </xmp>
@@ -2180,8 +2180,8 @@ To check if a {{VideoEncoderConfig}} is a <dfn>valid VideoEncoderConfig</dfn>,
 
   <dt><dfn dict-member for=VideoEncoderConfig>bitrateMode</dfn></dt>
   <dd>
-    Configures encoding to use a {{BitrateMode/constant}} or
-    {{BitrateMode/variable}} bitrate as defined by [[MEDIASTREAM-RECORDING]].
+    Configures encoding to use one of the rate control modes specified by
+    {{VideoEncoderBitrateMode}}.
 
     NOTE: The precise degree of bitrate fluctuation in either mode is
         implementation defined.
@@ -2359,6 +2359,9 @@ dictionary VideoEncoderEncodeOptions {
 };
 </xmp>
 
+NOTE: Codec-specific extensions to {{VideoEncoderEncodeOptions}} are described in
+    their registrations in the [[WEBCODECS-CODEC-REGISTRY]].
+
 <dl>
   <dt><dfn dict-member for=VideoEncoderEncodeOptions>keyFrame</dfn></dt>
   <dd>
@@ -2367,6 +2370,34 @@ dictionary VideoEncoderEncodeOptions {
     decide whether the frame will be encoded as a [=key frame=].
   </dd>
 </dl>
+
+
+VideoEncoderBitrateMode{#video-encoder-bitrate-mode}
+-------------------------------------------
+<xmp class='idl'>
+  enum VideoEncoderBitrateMode {
+    "constant",
+    "variable",
+    "quantizer"
+  };
+</xmp>
+
+<dl>
+  <dt><dfn enum-value for=VideoEncoderBitrateMode>constant</dfn></dt>
+  <dd>Encode at a constant bitrate. See {{VideoEncoderConfig/bitrate}}.</dd>
+  <dt><dfn enum-value for=VideoEncoderBitrateMode>variable</dfn></dt>
+  <dd>
+    Encode using a variable bitrate, allowing more space to be used for
+    complex signals and less space for less complex signals.
+    See {{VideoEncoderConfig/bitrate}}.
+  </dd>
+  <dt><dfn enum-value for=VideoEncoderBitrateMode>quantizer</dfn></dt>
+  <dd>
+    Encode using a quantizer, that is specified for each video
+    frame in codec specific extensions of {{VideoEncoderEncodeOptions}}.
+  </dd>
+</dl>
+
 
 
 CodecState{#codec-state}

--- a/vp9_codec_registration.src.html
+++ b/vp9_codec_registration.src.html
@@ -16,7 +16,8 @@ Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     (2) the codec-specific {{EncodedVideoChunk}}
     {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the
     {{VideoDecoderConfig/description|VideoDecoderConfig.description}} bytes,
-    and (4) the values of {{EncodedVideoChunk}} {{EncodedVideoChunk/[[type]]}}.
+    (4) the values of {{EncodedVideoChunk}} {{EncodedVideoChunk/[[type]]}}, and
+    (5) the codec-specific extensions to {{VideoEncoderEncodeOptions}}.
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -71,6 +72,43 @@ If an {{EncodedVideoChunk}}'s {{EncodedVideoChunk/[[type]]}} is
 {{EncodedVideoChunkType/key}}, then the {{EncodedVideoChunk}} is expected to
 contain a frame with a `frame_type` of `KEY_FRAME` as defined in Section
 7.2 of [[VP9]].
+
+VideoEncoderEncodeOptions extensions {#videoencoderencodeoptions-extensions}
+==============================================================
+
+<pre class='idl'>
+<xmp>
+partial dictionary VideoEncoderEncodeOptions {
+  VideoEncoderEncodeOptionsForVp9 vp9;
+};
+</xmp>
+</pre>
+
+<dl>
+  <dt><dfn dict-member for=VideoEncoderEncodeOptions>vp9</dfn></dt>
+  <dd>
+    Contains codec specific encode options for the [[VP9]] codec.
+  </dd>
+</dl>
+
+VideoEncoderEncodeOptionsForVp9 {#vp9-encode-options}
+--------------------------------------
+<pre class='idl'>
+<xmp>
+dictionary VideoEncoderEncodeOptionsForVp9 {
+  unsigned short? quantizer;
+};
+</xmp>
+</pre>
+
+<dl>
+  <dt><dfn dict-member for=VideoEncoderEncodeOptionsForVp9>quantizer</dfn></dt>
+  <dd>
+    Sets per-frame quantizer value.
+    In [[VP9]] the quantizer threshold can be varied from 0 to 63
+  </dd>
+</dl>
+
 
 Privacy Considerations {#privacy-considerations}
 ==========================================================================


### PR DESCRIPTION
A codec specific quantizer is set for each video frame for constant quality or fine tuned external rate control.

Addressing Issue [270](https://github.com/w3c/webcodecs/issues/270)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Djuffin/webcodecs/pull/633.html" title="Last updated on Feb 28, 2023, 7:38 AM UTC (40954c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/633/704c167...Djuffin:40954c3.html" title="Last updated on Feb 28, 2023, 7:38 AM UTC (40954c3)">Diff</a>