### PR TITLE
Extend EncodedVideoChunkMetadata

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -128,6 +128,16 @@ Definitions {#definitions}
 :: A grouping of {{EncodedVideoChunk}}s whose timestamp cadence produces a
     particular framerate. See {{VideoEncoderConfig/scalabilityMode}}.
 
+: <dfn>Spatial Layer</dfn>
+:: A grouping of {{EncodedVideoChunk}}s that produces a particular resolution.
+   See {{VideoEncoderConfig/scalabilityMode}}.
+
+: <dfn>Decode Target</dfn>
+:: A numerical index determined by the encoder that indicates the set of frames
+   needed to decode a sequence of {{EncodedVideoChunk}}s at a given spatial and
+   temporal fidelity. Values do not necessarily correspond to a given temporal
+   or spatial layer.
+
 : <dfn>Progressive Image</dfn>
 :: An image that supports decoding to multiple levels of detail, with lower
     levels becoming available while the encoded data is not yet fully buffered.
@@ -1639,11 +1649,20 @@ Algorithms {#videoencoder-algorithms}
                 |svc|.{{SvcOutputMetadata/temporalLayerId}}.
             4. Assign |svc| to
                 |chunkMetadata|.{{EncodedVideoChunkMetadata/svc}}.
-        8. If |encoderConfig|.{{VideoEncoderConfig/alpha}} is set to `"keep"`:
+        8. If |encoderConfig|.{{VideoEncoderConfig/scalabilityMode}}
+            describes multiple [=spatial layers=]:
+            1. Let |svc| be a new {{SvcOutputMetadata}} instance.
+            2. Let |spatial_layer_id| be the zero-based index describing the
+                spatial layer for |output|.
+            3. Assign |spatial_layer_id| to
+                |svc|.{{SvcOutputMetadata/spatiallLayerId}}.
+            4. Assign |svc| to
+                |chunkMetadata|.{{EncodedVideoChunkMetadata/svc}}.
+        9. If |encoderConfig|.{{VideoEncoderConfig/alpha}} is set to `"keep"`:
             1. Let |alphaSideData| be the encoded alpha data in |output|.
             2. Assign |alphaSideData| to
                 |chunkMetadata|.{{EncodedVideoChunkMetadata/alphaSideData}}.
-        9. Invoke {{VideoEncoder/[[output callback]]}} with |chunk| and
+       10. Invoke {{VideoEncoder/[[output callback]]}} with |chunk| and
             |chunkMetadata|.
   </dd>
   <dt><dfn>Reset VideoEncoder</dfn> (with |exception|)</dt>
@@ -1692,6 +1711,11 @@ dictionary EncodedVideoChunkMetadata {
 
 dictionary SvcOutputMetadata {
   unsigned long temporalLayerId;
+  unsigned long spatiallayerId;
+  unsigned short frameNumber;
+  sequence<unsigned long> dependsOnIds;
+  sequence<unsigned long> decodeTargets;
+  map<unsigned long, unsigned long> chainLinks;
 };
 </xmp>
 
@@ -1711,6 +1735,26 @@ dictionary SvcOutputMetadata {
 :: A number that identifies the [=temporal layer=] for the associated
     {{EncodedVideoChunk}}.
 
+: <dfn dict-member for=SvcOutputMetadata>spatialLayerId</dfn>
+:: A number that identifies the [=spatial layer=] for the associated
+    {{EncodedVideoChunk}}.
+
+: <dfn dict-member for=SvcOutputMetadata>frameNumber</dfn>
+:: A number that identifies the frame in {{dependsOnIds}} and 
+  {{chainLinks}} (for other {{EncodedVideoChunk}}s).
+
+: <dfn dict-member for=SvcOutputMetadata>dependsOnIds</dfn>
+:: A sequence of {{frameNumber}} values that this {{EncodedVideoChunk}}
+   depends on.
+
+: <dfn dict-member for=SvcOutputMetadata>decodeTargets</dfn>
+:: A sequence of [=Decode Target=] values that this {{EncodedVideoChunk}}
+   participates in.
+
+: <dfn dict-member for=SvcOutputMetadata>chainLinks</dfn>
+:: A mapping of [=Decode Target=] values to the last important frame to
+   decode prior to this {{EncodedVideoChunk}}, for a given
+   [=Decode Target=] value.
 
 Configurations{#configurations}
 ===============================

--- a/index.src.html
+++ b/index.src.html
@@ -54,6 +54,15 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
 
 <pre class='biblio'>
 {
+  "AV1-RTP": {
+    "title": "RTP Payload Format for AV1",
+    "href": "https://aomediacodec.github.io/av1-rtp-spec/",
+    "authors": [
+      "AV1 RTC SG"
+    ],
+    "status": "Standard",
+    "publisher": "Alliance for Open Media"
+  },
   "H.273": {
     "href": "https://www.itu.int/rec/T-REC-H.273/en",
     "title": "Coding-independent code points for video signal type identification",

--- a/index.src.html
+++ b/index.src.html
@@ -131,6 +131,14 @@ Definitions {#definitions}
 : <dfn>Spatial Layer</dfn>
 :: A grouping of {{EncodedVideoChunk}}s that produces a particular resolution.
     See {{VideoEncoderConfig/scalabilityMode}}.
+    
+: <dfn>Chain</dfn>
+:: A sequence of frames for which it can be determined instantly if a frame
+from that sequence has been lost.
+
+: <dfn>frame_number</dfn>
+:: A 16-bit number that increases strictly monotonically in decode order.
+Defined in [[AV1-RTP]] Section A.8.3. 
 
 : <dfn>Decode Target</dfn>
 :: A numerical index determined by the encoder that indicates the set of frames

--- a/index.src.html
+++ b/index.src.html
@@ -130,13 +130,13 @@ Definitions {#definitions}
 
 : <dfn>Spatial Layer</dfn>
 :: A grouping of {{EncodedVideoChunk}}s that produces a particular resolution.
-   See {{VideoEncoderConfig/scalabilityMode}}.
+    See {{VideoEncoderConfig/scalabilityMode}}.
 
 : <dfn>Decode Target</dfn>
 :: A numerical index determined by the encoder that indicates the set of frames
-   needed to decode a sequence of {{EncodedVideoChunk}}s at a given spatial and
-   temporal fidelity. Values do not necessarily correspond to a given temporal
-   or spatial layer.
+    needed to decode a sequence of {{EncodedVideoChunk}}s at a given spatial and
+    temporal fidelity. Values do not necessarily correspond to a given
+    [=Temporal Layer=] or [=Spatial Layer=].
 
 : <dfn>Progressive Image</dfn>
 :: An image that supports decoding to multiple levels of detail, with lower
@@ -1732,16 +1732,16 @@ dictionary SvcOutputMetadata {
     channel data.
 
 : <dfn dict-member for=SvcOutputMetadata>temporalLayerId</dfn>
-:: A number that identifies the [=temporal layer=] for the associated
+:: A number that identifies the [=Temporal Layer=] for the associated
     {{EncodedVideoChunk}}.
 
 : <dfn dict-member for=SvcOutputMetadata>spatialLayerId</dfn>
-:: A number that identifies the [=spatial layer=] for the associated
+:: A number that identifies the [=Spatial Layer=] for the associated
     {{EncodedVideoChunk}}.
 
 : <dfn dict-member for=SvcOutputMetadata>frameNumber</dfn>
 :: A number that identifies the frame in {{dependsOnIds}} and 
-  {{chainLinks}} (for other {{EncodedVideoChunk}}s).
+  {{chainLinks}} (for other {{EncodedVideoChunk}} values).
 
 : <dfn dict-member for=SvcOutputMetadata>dependsOnIds</dfn>
 :: A sequence of {{frameNumber}} values that this {{EncodedVideoChunk}}

--- a/index.src.html
+++ b/index.src.html
@@ -134,12 +134,12 @@ Definitions {#definitions}
     
 : <dfn>Chains</dfn>
 :: {{chainLinks}} represents a sequence of frames for which it can be determined
-    instantly if a frame from that sequence has been lost. Defined in [[AV1-RTP]]
-    Section A.5.
+    instantly if a frame from that sequence has been lost. Defined in Section A.5
+    of [[AV1-RTP]].
 
 : <dfn>Frame Number</dfn>
 :: {{frameNumber}} is a 16-bit number that increases strictly monotonically in
-    decode order. Defined in [[AV1-RTP]] Section A.8.3. 
+    decode order. Defined in Section A.8.3 of [[AV1-RTP]]. 
 
 : <dfn>Decode Target</dfn>
 :: A numerical index determined by the encoder that indicates the set of frames

--- a/index.src.html
+++ b/index.src.html
@@ -132,11 +132,11 @@ Definitions {#definitions}
 :: A grouping of {{EncodedVideoChunk}}s that produces a particular resolution.
     See {{VideoEncoderConfig/scalabilityMode}}.
     
-: <dfn>Chain</dfn>
+: <dfn>chainLinks</dfn>
 :: A sequence of frames for which it can be determined instantly if a frame
-from that sequence has been lost.
+from that sequence has been lost. Defined in [[AV1-RTP]] Section A.5.
 
-: <dfn>frame_number</dfn>
+: <dfn>frameNumber</dfn>
 :: A 16-bit number that increases strictly monotonically in decode order.
 Defined in [[AV1-RTP]] Section A.8.3. 
 

--- a/index.src.html
+++ b/index.src.html
@@ -132,13 +132,14 @@ Definitions {#definitions}
 :: A grouping of {{EncodedVideoChunk}}s that produces a particular resolution.
     See {{VideoEncoderConfig/scalabilityMode}}.
     
-: <dfn>chainLinks</dfn>
-:: A sequence of frames for which it can be determined instantly if a frame
-from that sequence has been lost. Defined in [[AV1-RTP]] Section A.5.
+: <dfn>Chains</dfn>
+:: {{chainLinks}} represents a sequence of frames for which it can be determined
+    instantly if a frame from that sequence has been lost. Defined in [[AV1-RTP]]
+    Section A.5.
 
-: <dfn>frameNumber</dfn>
-:: A 16-bit number that increases strictly monotonically in decode order.
-Defined in [[AV1-RTP]] Section A.8.3. 
+: <dfn>Frame Number</dfn>
+:: {{frameNumber}} is a 16-bit number that increases strictly monotonically in
+    decode order. Defined in [[AV1-RTP]] Section A.8.3. 
 
 : <dfn>Decode Target</dfn>
 :: A numerical index determined by the encoder that indicates the set of frames
@@ -1760,8 +1761,8 @@ dictionary SvcOutputMetadata {
    participates in.
 
 : <dfn dict-member for=SvcOutputMetadata>chainLinks</dfn>
-:: A mapping of [=Decode Target=] values to the last important frame to
-   decode prior to this {{EncodedVideoChunk}}, for a given
+:: A mapping of [=Decode Target=] values to the last important frame
+   to decode prior to this {{EncodedVideoChunk}}, for a given
    [=Decode Target=] value.
 
 Configurations{#configurations}


### PR DESCRIPTION
Fixes https://github.com/w3c/webcodecs/issues/619


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 16, 2023, 3:22 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Faboba%2Fwebcodecs%2F0a2ac63b4136285967fe03e4d4a20ba86e5bd037%2Findex.src.html&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Quoted attribute was never closed
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webcodecs%23636.)._
</details>
