### PR TITLE
Annotate encoder/decoders with EventTarget on ondequeue events.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -256,7 +256,7 @@ AudioDecoder Interface {#audiodecoder-interface}
 
 <xmp class='idl'>
 [Exposed=(Window,DedicatedWorker), SecureContext]
-interface AudioDecoder {
+interface AudioDecoder : EventTarget {
   constructor(AudioDecoderInit init);
 
   readonly attribute CodecState state;
@@ -583,7 +583,7 @@ VideoDecoder Interface {#videodecoder-interface}
 
 <xmp class='idl'>
 [Exposed=(Window,DedicatedWorker), SecureContext]
-interface VideoDecoder {
+interface VideoDecoder : EventTarget {
   constructor(VideoDecoderInit init);
 
   readonly attribute CodecState state;
@@ -937,7 +937,7 @@ AudioEncoder Interface {#audioencoder-interface}
 
 <xmp class='idl'>
 [Exposed=(Window,DedicatedWorker), SecureContext]
-interface AudioEncoder {
+interface AudioEncoder : EventTarget {
   constructor(AudioEncoderInit init);
 
   readonly attribute CodecState state;
@@ -1310,7 +1310,7 @@ VideoEncoder Interface {#videoencoder-interface}
 
 <xmp class='idl'>
 [Exposed=(Window,DedicatedWorker), SecureContext]
-interface VideoEncoder {
+interface VideoEncoder : EventTarget {
   constructor(VideoEncoderInit init);
 
   readonly attribute CodecState state;


### PR DESCRIPTION
Seems to be an oversight from when ondequeue events were added. Allows the idlharness.js test to start passing.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/637.html" title="Last updated on Feb 3, 2023, 8:32 PM UTC (734bd7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/637/c846f98...734bd7a.html" title="Last updated on Feb 3, 2023, 8:32 PM UTC (734bd7a)">Diff</a>