### PR TITLE
Fix auto-publication of the WebCodecs Codec Registry

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -32,7 +32,7 @@ jobs:
             destination: codec_registry.html
             echidna_token: ECHIDNA_TOKEN_REGISTRY
             build_override: |
-              status: NOTE-WD
+              status: DRY
           - source: avc_codec_registration.src.html
             destination: avc_codec_registration.html
             echidna_token: ECHIDNA_TOKEN_AVC_REGISTRATION


### PR DESCRIPTION
The requested status was still "Note" whereas the spec transitioned to the Registry track. Updating the status accordingly.

Note that the job succeeded because it failed to detect the error returned by Echidna to complain about the incorrect status. Spec updates were not published though (and the /TR version is still the October 2022 version for now).