### PR TITLE
Introducing a generic 'quantizer' mode for VideoEncoder

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2073,7 +2073,7 @@ dictionary VideoEncoderConfig {
   HardwareAcceleration hardwareAcceleration = "no-preference";
   AlphaOption alpha = "discard";
   DOMString scalabilityMode;
-  BitrateMode bitrateMode = "variable";
+  VideoEncoderBitrateMode bitrateMode = "variable";
   LatencyMode latencyMode = "quality";
 };
 </xmp>
@@ -2180,8 +2180,8 @@ To check if a {{VideoEncoderConfig}} is a <dfn>valid VideoEncoderConfig</dfn>,
 
   <dt><dfn dict-member for=VideoEncoderConfig>bitrateMode</dfn></dt>
   <dd>
-    Configures encoding to use a {{BitrateMode/constant}} or
-    {{BitrateMode/variable}} bitrate as defined by [[MEDIASTREAM-RECORDING]].
+    Configures encoding to use one of the rate control modes specified by
+    {{VideoEncoderBitrateMode}}.
 
     NOTE: The precise degree of bitrate fluctuation in either mode is
         implementation defined.
@@ -2356,6 +2356,7 @@ VideoEncoderEncodeOptions{#video-encoder-options}
 <xmp class='idl'>
 dictionary VideoEncoderEncodeOptions {
   boolean keyFrame = false;
+  double? quantizer;
 };
 </xmp>
 
@@ -2365,6 +2366,40 @@ dictionary VideoEncoderEncodeOptions {
     A value of `true` indicates that the given frame MUST be encoded as a key
     frame. A value of `false` indicates that the User Agent has flexibility to
     decide whether the frame will be encoded as a [=key frame=].
+  </dd>
+  <dt><dfn dict-member for=VideoEncoderEncodeOptions>quantizer</dfn></dt>
+  <dd>
+    Sets per-frame quantizer value.
+
+    The ranges of codec specific quantizer values are defined in the
+    [[WEBCODECS-CODEC-REGISTRY]].
+  </dd>
+</dl>
+
+
+VideoEncoderBitrateMode{#video-encoder-bitrate-mode}
+-------------------------------------------
+<xmp class='idl'>
+  enum VideoEncoderBitrateMode {
+    "constant",
+    "variable",
+    "quantizer"
+  };
+</xmp>
+
+<dl>
+  <dt><dfn enum-value for=VideoEncoderBitrateMode>constant</dfn></dt>
+  <dd>Encode at a constant bitrate. See {{VideoEncoderConfig/bitrate}}.</dd>
+  <dt><dfn enum-value for=VideoEncoderBitrateMode>variable</dfn></dt>
+  <dd>
+    Encode using a variable bitrate, allowing more space to be used for
+    complex signals and less space for less complex signals.
+    See {{VideoEncoderConfig/bitrate}}.
+  </dd>
+  <dt><dfn enum-value for=VideoEncoderBitrateMode>quantizer</dfn></dt>
+  <dd>
+    Encode using a quantizer, that is specified for each video
+    frame in {{VideoEncoderEncodeOptions/quantizer}}.
   </dd>
 </dl>
 

--- a/vp9_codec_registration.src.html
+++ b/vp9_codec_registration.src.html
@@ -16,7 +16,8 @@ Abstract: This registration is entered into the [[webcodecs-codec-registry]].
     (2) the codec-specific {{EncodedVideoChunk}}
     {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the
     {{VideoDecoderConfig/description|VideoDecoderConfig.description}} bytes,
-    and (4) the values of {{EncodedVideoChunk}} {{EncodedVideoChunk/[[type]]}}.
+    (4) the values of {{EncodedVideoChunk}} {{EncodedVideoChunk/[[type]]}}, and
+    (5) the range of values of {{VideoEncoderEncodeOptions}} {{VideoEncoderEncodeOptions/[[quantizer]]}}.
 
     The registration is not intended to include any information on whether a
     codec format is encumbered by intellectual property claims. Implementers and
@@ -71,6 +72,12 @@ If an {{EncodedVideoChunk}}'s {{EncodedVideoChunk/[[type]]}} is
 {{EncodedVideoChunkType/key}}, then the {{EncodedVideoChunk}} is expected to
 contain a frame with a `frame_type` of `KEY_FRAME` as defined in Section
 7.2 of [[VP9]].
+
+VideoEncoderEncodeOptions quantizer {#videoencoderencodeoptions-quantizer}
+================================================
+
+In [[VP9]] the {{VideoEncoderEncodeOptions/quantizer}} values can be from 0 to 63.
+
 
 Privacy Considerations {#privacy-considerations}
 ==========================================================================


### PR DESCRIPTION
A generic quantizer is specified for each video frame for constant quality or fine tuned external rate control.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Djuffin/webcodecs/pull/642.html" title="Last updated on Feb 28, 2023, 7:40 AM UTC (cc65d1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/642/704c167...Djuffin:cc65d1b.html" title="Last updated on Feb 28, 2023, 7:40 AM UTC (cc65d1b)">Diff</a>