### PR TITLE
Fix usage of {Audio/Video}Decoder.isConfigSupported() in example

### DIFF
--- a/samples/lib/audio_renderer.js
+++ b/samples/lib/audio_renderer.js
@@ -31,7 +31,8 @@ export class AudioRenderer {
 
     debugLog(config);
 
-    console.assert(AudioDecoder.isConfigSupported(config));
+    let support = await AudioDecoder.isConfigSupported(config);
+    console.assert(support.supported);
     this.decoder.configure(config);
 
     // Initialize the ring buffer between the decoder and the real-time audio

--- a/samples/lib/video_renderer.js
+++ b/samples/lib/video_renderer.js
@@ -31,7 +31,9 @@ export class VideoRenderer {
       output: this.bufferFrame.bind(this),
       error: e => console.error(e),
     });
-    console.assert(VideoDecoder.isConfigSupported(config))
+
+    let support = await VideoDecoder.isConfigSupported(config);
+    console.assert(support.supported);
     this.decoder.configure(config);
 
     this.init_resolver = null;


### PR DESCRIPTION
I've noticed that the usage of `isConfigSupported()` in the example is probably not as intended. So far the assertion only checks if `isConfigSupported()` returns a truthy value which is always the case.

I've changed the code to match the usage here: 
https://github.com/w3c/webcodecs/blob/34e21cb731360339b249ceeb6234129a011b92c9/samples/capture-to-file/encode-worker.js#L38-L39

Please let me know if there is anything I should change.