### PR TITLE
Use is not origin-clean concept in VideoFrame constructor

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -39,6 +39,7 @@ spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
         type: dfn; text: bitmap data; url: imagebitmap-and-animations.html#concept-imagebitmap-bitmap-data
     for: Canvas;
         type: dfn; text: Check the usability of the image argument; url: canvas.html#check-the-usability-of-the-image-argument
+        type: dfn; text: is not origin-clean; url: canvas.html#the-image-argument-is-not-origin-clean
     for: webappapis;
         type: dfn; text: entry settings object; url: webappapis.html#entry-settings-object
     for: media;
@@ -3335,10 +3336,7 @@ dictionary VideoFrameMetadata {
 1. [=Canvas/Check the usability of the image argument=]. If this throws an
     exception or returns <var ignore=''>bad</var>, then throw an
     {{InvalidStateError}} {{DOMException}}.
-2. If the [=/origin=] of |image|'s image data is not [=same origin=]
-    with the [=webappapis/entry settings object=]'s
-    [=/origin=], then throw a {{SecurityError}}
-    {{DOMException}}.
+2. If |image| [=Canvas/is not origin-clean=], then throw a {{SecurityError}} {{DOMException}}.
 3. Let |frame| be a new {{VideoFrame}}.
 5. Switch on |image|:
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 17, 2023, 10:24 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fyouennf%2Fwebcodecs%2F537e99dd7d761321ce691ce8edfa780c9d40f00f%2Findex.src.html&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Quoted attribute was never closed
 ✘  Did not generate, due to fatal errors
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webcodecs%23655.)._
</details>
