### PR TITLE
Define videoSource before videoSelect.onchange to avoid ReferenceError.

### DIFF
--- a/samples/encode-decode-worker/js/main.js
+++ b/samples/encode-decode-worker/js/main.js
@@ -9,6 +9,7 @@ let latencyPref = "realtime", bitPref = "variable";
 let hw = "no-preference";
 let streamWorker;
 let inputStream, outputStream;
+let videoSource;
 const rate = document.querySelector('#rate');
 const connectButton = document.querySelector('#connect');
 const stopButton = document.querySelector('#stop');


### PR DESCRIPTION
This fixes the error popup when doing video source switch.