### PR TITLE
Replace RFC2119 wording in Security Considerations

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -5596,7 +5596,7 @@ are provided and direct access to invoke the codec control methods. This also
 affords attackers the ability to invoke sequences of control methods that were
 not previously possible via the higher level APIs.
 
-User Agents <em class="rfc2119">SHOULD</em> mitigate this risk by extensively
+The Working Group expects User Agents to mitigate this risk by extensively
 fuzzing their implementation with random inputs and control method invocations.
 Additionally, User Agents are encouraged to isolate their underlying codecs in
 processes with restricted privileges (sandbox) as a barrier against successful


### PR DESCRIPTION
See https://github.com/w3c/webcodecs/pull/685#issuecomment-1602409644. This removes the last remaining SHOULD in the Security Considerations section.

Fixes https://github.com/w3c/webcodecs/issues/689


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/691.html" title="Last updated on Jun 22, 2023, 9:46 PM UTC (f648a57)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/691/fb21d67...f648a57.html" title="Last updated on Jun 22, 2023, 9:46 PM UTC (f648a57)">Diff</a>