### PR TITLE
Add to codec registry requirements

### DIFF
--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -45,7 +45,7 @@ Registration Entry Requirements {#registration-entry-requirements}
 ==================================================================
 
 1. Each entry must include a unique codec string, a common name string, and a
-    link to a public specification.
+    link to a stable public specification.
 2. The codec string must be crafted as follows:
     1. If the codec string contains a fixed prefix with variable suffix values,
         the suffix must be represented by an asterisk and the registration's
@@ -62,17 +62,19 @@ Registration Entry Requirements {#registration-entry-requirements}
     3. {{AudioDecoderConfig}} or {{VideoDecoderConfig}} description bytes
     4. Expectations for {{EncodedAudioChunk}} or {{EncodedVideoChunk}}
         {{EncodedVideoChunk/[[type]]}}
-3. Where applicable, a registration specification may include a section
+4. Where applicable, a registration specification may include a section
     describing extensions to {{VideoEncoderConfig}} or {{AudioEncoderConfig}}
     dictionaries.
-4. Candidate entries must be announced by filing an issue in the
+5. Candidate entries must be announced by filing an issue in the
     [WebCodecs GitHub issue tracker](https://github.com/w3c/webcodecs/issues/)
     so they can be discussed and evaluated for compliance before being added to
-    the registry. If the Media Working Group reaches consensus to accept the
-    candidate, a pull request should be drafted (either by editors or by the
-    party requesting the candidate registration) to register the candidate. The
-    registry editors will review and merge the pull request.
-5. Existing entries cannot be deleted or deprecated. They may be changed after
+    the registry. The Media Working Group may seek expertise from outside the
+    Working Group as part of its evaluation, e.g., from the codec specification
+    editors or relevant standards group. If the Working Group reaches consensus
+    to accept the candidate, a pull request should be drafted (either by editors
+    or by the party requesting the candidate registration) to register the
+    candidate. The registry editors will review and merge the pull request.
+6. Existing entries cannot be deleted or deprecated. They may be changed after
     being published through the same process as candidate entries. Possible
     changes include expansion of the codec string to better qualify the codec,
     adjustments to the codec name string, and modification of the link to the

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -1,7 +1,7 @@
 <pre class='metadata'>
 Title: WebCodecs Codec Registry
 Repository: w3c/webcodecs
-Status: NOTE-ED
+Status: DRY
 Shortname: webcodecs-codec-registry
 Level: none
 Group: mediawg
@@ -45,7 +45,7 @@ Registration Entry Requirements {#registration-entry-requirements}
 ==================================================================
 
 1. Each entry must include a unique codec string, a common name string, and a
-    link to a stable public specification.
+    link to a public specification.
 2. The codec string must be crafted as follows:
     1. If the codec string contains a fixed prefix with variable suffix values,
         the suffix must be represented by an asterisk and the registration's


### PR DESCRIPTION
This is intended to resolve #426.

- Added a requirement for a public specification that is stable
- Added that the WG may consult external expertise as part of its review (but not go so far as producing a written review with a recommendation, as #426 suggested)
- Fixes the numbering in the source document

@aboba for review