### PR TITLE
Add AudioEncoderConfig.bitrateMode default

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2033,7 +2033,7 @@ dictionary AudioEncoderConfig {
   [EnforceRange] unsigned long sampleRate;
   [EnforceRange] unsigned long numberOfChannels;
   [EnforceRange] unsigned long long bitrate;
-  BitrateMode bitrateMode;
+  BitrateMode bitrateMode = "variable";
 };
 </xmp>
 


### PR DESCRIPTION
This PR fixes #699.

It sets `AudioEncoderConfig.bitrateMode` to `"variable"` by default. This matches the VideoEncoder's behavior, and the behavior from the [media recorder spec](https://w3c.github.io/mediacapture-record/#dom-mediarecorderoptions-audiobitratemode).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tguilbert-google/webcodecs/pull/700.html" title="Last updated on Jul 6, 2023, 7:44 PM UTC (7c5143b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/700/249e328...tguilbert-google:7c5143b.html" title="Last updated on Jul 6, 2023, 7:44 PM UTC (7c5143b)">Diff</a>