### PR TITLE
Set optimizeForLatency in decoder config

### DIFF
--- a/samples/encode-decode-worker/js/stream_worker.js
+++ b/samples/encode-decode-worker/js/stream_worker.js
@@ -252,6 +252,8 @@ class pipeline {
            output: (chunk, cfg) => {
              if (cfg.decoderConfig) {
                cfg.decoderConfig.hardwareAcceleration = config.decHwAcceleration;
+               cfg.decoderConfig.optimizeForLatency = true;
+               if (config.latencyPref == 'quality') cfg.decoderConfig.optimizeForLatency = false;
                const decoderConfig = JSON.stringify(cfg.decoderConfig);
                self.postMessage({text: 'Configuration: ' + decoderConfig});
                const configChunk =


### PR DESCRIPTION
When the encoder spits out a decoder configuration, set optimizeForLatency based on the encoder configuration of latencyPref.