### PR TITLE
Assign [[format]] in VideoFrame ctor

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3592,7 +3592,9 @@ dictionary VideoFrameMetadata {
     7. Let |colorSpace| be `undefined`.
     8. If |init|.{{VideoFrameBufferInit/colorSpace}} [=map/exists=], assign its
         value to |colorSpace|.
-    9. Assign the result of running the [=VideoFrame/Pick Color Space=]
+    9. Assign |init|'s {{VideoFrameBufferInit/format}} to
+        {{VideoFrame/[[format]]}}.
+    10. Assign the result of running the [=VideoFrame/Pick Color Space=]
         algorithm, with |colorSpace| and {{VideoFrame/[[format]]}}, to
         {{VideoFrame/[[color space]]}}.
     10. Assign the result of calling [=Copy VideoFrame metadata=]

--- a/index.src.html
+++ b/index.src.html
@@ -2086,7 +2086,9 @@ run these steps:
     Configures the encoder to use a {{BitrateMode/constant}} or
     {{BitrateMode/variable}} bitrate as defined by [[MEDIASTREAM-RECORDING]].
 
-	NOTE: Not all audio codecs support specific {{BitrateMode}}s, Authors are encouraged to check by calling {{AudioEncoder/isConfigSupported()}} with |config|.
+    NOTE: Not all audio codecs support specific {{BitrateMode}}s, Authors are
+    encouraged to check by calling {{AudioEncoder/isConfigSupported()}} with
+    |config|.
   </dd>
 </dl>
 
@@ -3597,8 +3599,9 @@ dictionary VideoFrameMetadata {
     10. Assign the result of running the [=VideoFrame/Pick Color Space=]
         algorithm, with |colorSpace| and {{VideoFrame/[[format]]}}, to
         {{VideoFrame/[[color space]]}}.
-    10. Assign the result of calling [=Copy VideoFrame metadata=]
-        with |init|'s {{VideoFrameInit/metadata}} to |frame|.{{VideoFrame/[[metadata]]}}.
+    11. Assign the result of calling [=Copy VideoFrame metadata=]
+        with |init|'s {{VideoFrameInit/metadata}} to
+        |frame|.{{VideoFrame/[[metadata]]}}.
 22. Return |frame|.
 
 ### Attributes ###{#videoframe-attributes}


### PR DESCRIPTION
Does what it says. Whitespace fixes split in a different patches for clarity.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/737.html" title="Last updated on Oct 31, 2023, 2:13 PM UTC (61860a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/737/3c9e353...61860a3.html" title="Last updated on Oct 31, 2023, 2:13 PM UTC (61860a3)">Diff</a>