### PR TITLE
Resolve VideoFrame.copyTo with the list of layout

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3744,7 +3744,8 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
         {{TypeError}}.
     6. Let |p| be a new {{Promise}}.
     7. Let |copyStepsQueue| be the result of starting a new [=parallel queue=].
-    8. Enqueue the following steps to |copyStepsQueue|:
+    8. Let |planeLayouts| be a new [=list=].
+    9. Enqueue the following steps to |copyStepsQueue|:
         1. Let resource be the [=media resource=] referenced by
             [[resource reference]].
         2. Let |numPlanes| be the number of planes as defined by
@@ -3760,13 +3761,16 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
                 |computedLayout|'s [=computed plane layout/sourceTop=] by
                 |sourceStride|
             4. Add |computedLayout|'s [=computed plane layout/sourceLeftBytes=]
-                to sourceOffset.
+                to |sourceOffset|.
             5. Let |destinationOffset| be |computedLayout|'s
                 [=computed plane layout/destinationOffset=].
             6. Let |rowBytes| be |computedLayout|'s
                 [=computed plane layout/sourceWidthBytes=].
-            7. Let |row| be `0`.
-            8. While |row| is less than |computedLayout|'s
+            7. Let |layout| be a new {{PlaneLayout}}, with
+                {{PlaneLayout/offset}} set to |destinationOffset| and
+                {{PlaneLayout/stride}} set to |rowBytes|.
+            8. Let |row| be `0`.
+            9. While |row| is less than |computedLayout|'s
                 [=computed plane layout/sourceHeight=]:
                 1. Copy |rowBytes| bytes from |resource| starting at
                     |sourceOffset| to |destination| starting at
@@ -3775,9 +3779,10 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
                 3. Increment |destinationOffset| by |computedLayout|'s
                     [=computed plane layout/destinationStride=].
                 4. Increment |row| by `1`.
-            9. Increment |planeIndex| by `1`.
-        5. [=Queue a task=] to resolve |p|.
-    9. Return |p|.
+            10. Increment |planeIndex| by `1`.
+            11. Append |layout| to |planeLayouts|.
+        5. [=Queue a task=] to resolve |p| with |planeLayouts|.
+    10. Return |p|.
 
 : <dfn method for=VideoFrame>clone()</dfn>
 :: Creates a new {{VideoFrame}} with a reference to the same


### PR DESCRIPTION
This fixes #510.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/738.html" title="Last updated on Oct 31, 2023, 2:32 PM UTC (441d96c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/738/3c9e353...441d96c.html" title="Last updated on Oct 31, 2023, 2:32 PM UTC (441d96c)">Diff</a>