### PR TITLE
Fix incorrect computation in Compute Layout and Allocation Size when figuring out the destination rect

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4093,10 +4093,12 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
             to the nearest integer.
         9. Set |computedLayout|'s [=computed plane layout/sourceLeftBytes=] to
             the result of the integer division of
-            truncated |parsedRect|.{{DOMRectInit/x}} by |sampleWidthBytes|.
+            truncated |parsedRect|.{{DOMRectInit/x}} by |sampleWidth|,
+            multiplied by |sampleBytes|.
         10. Set |computedLayout|'s [=computed plane layout/sourceWidthBytes=] to
             the result of the integer division of
-            truncated |parsedRect|.{{DOMRectInit/width}} by |sampleWidthBytes|.
+            truncated |parsedRect|.{{DOMRectInit/width}} by |sampleHeight|,
+            multiplied by |sampleBytes|.
         11. If |layout| is not `undefined`:
             1. Let |planeLayout| be the {{PlaneLayout}} in |layout| at position
                 |planeIndex|.


### PR DESCRIPTION
This fixes #511.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/739.html" title="Last updated on Oct 31, 2023, 2:39 PM UTC (51ee334)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/739/3c9e353...51ee334.html" title="Last updated on Oct 31, 2023, 2:39 PM UTC (51ee334)">Diff</a>