### PR TITLE
Use the correct size in "Output EncodedVideoChunks" algorithm when outputing decoder config

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1620,13 +1620,13 @@ Algorithms {#videoencoder-algorithms}
             |output|. Initialize |outputConfig| as follows:
             1. Assign `encoderConfig.codec` to `outputConfig.codec`.
             2. Assign `encoderConfig.width` to
-                `outputConfig.visibleRect.width`.
+                `outputConfig.codedWidth`.
             3. Assign `encoderConfig.height` to
-                `outputConfig.visibleRect.height`.
+                `outputConfig.codedHeight`.
             4. Assign `encoderConfig.displayWidth` to
-                `outputConfig.displayWidth`.
+                `outputConfig.displayAspectWidth`.
             5. Assign `encoderConfig.displayHeight` to
-                `outputConfig.displayHeight`.
+                `outputConfig.displayAspectHeight`.
             6. Assign the remaining keys of `outputConfig` as determined by
                 {{VideoEncoder/[[codec implementation]]}}. The User Agent
                 <em class="rfc2119">MUST</em> ensure that the configuration is


### PR DESCRIPTION
Found while implementing, simple mistake but I think the intent is clear.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/749.html" title="Last updated on Nov 23, 2023, 10:49 AM UTC (f447169)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/749/a04d18b...f447169.html" title="Last updated on Nov 23, 2023, 10:49 AM UTC (f447169)">Diff</a>