### PR TITLE
Revert "Add screen content coding tools as an encoder configuration"

### DIFF
--- a/av1_codec_registration.src.html
+++ b/av1_codec_registration.src.html
@@ -75,47 +75,6 @@ If an {{EncodedVideoChunk}}'s {{EncodedVideoChunk/[[type]]}} is
 contain a frame with a `frame_type` of `KEY_FRAME` as defined in Section
 6.8.2 of [[AV1]].
 
-VideoEncoderConfig extensions {#videoencoderconfig-extensions}
-==============================================================
-
-<pre class='idl'>
-<xmp>
-partial dictionary VideoEncoderConfig {
-  AV1EncoderConfig av1;
-};
-</xmp>
-</pre>
-
-<dl>
-  <dt><dfn dict-member for=VideoEncoderConfig>av1</dfn></dt>
-  <dd>
-    Contains codec specific configuration options for the AV1 codec.
-  </dd>
-</dl>
-
-AV1EncoderConfig {#av1-encoder-config}
---------------------------------------
-<pre class='idl'>
-<xmp>
-dictionary AV1EncoderConfig {
-  boolean forceScreenContentTools = false;
-};
-</xmp>
-</pre>
-
-<dl>
-  <dt><dfn dict-member for=AV1EncoderConfig>forceScreenContentTools</dfn></dt>
-  <dd>
-     Indicates whether the encoder should force use of screen content
-     coding tools. The default value (false) indicates that use of
-     screen content coding tools is not forced. A value of true
-     (corresponding to setting seq_force_screen_content_tools
-     to SELECT_SCREEN_CONTENT_TOOLS in Section 5.5.1
-     of [[AV1]]) indicates that use of screen content coding tools
-     is forced.
-  </dd>
-</dl>
-
 VideoEncoderEncodeOptions extensions {#videoencoderencodeoptions-extensions}
 ==============================================================
 


### PR DESCRIPTION
`av1.forceScreenContentTools` was made practically obsolete by [contentHint](https://www.w3.org/TR/webcodecs/#dom-videoencoderconfig-contenthint), which does the same but in a codec-agnostic way.

It hasn't been implemented by any UA, and it's safe to remove from the spec.



This reverts commits:
b35c6a36cb45ceaea87344702aa1c53430daaa56
29f1a8a165c2a16dc9a0b7180bd23c5ac2f07215

Related issue: https://github.com/w3c/webcodecs/issues/646