### PR TITLE
Spec optional conversion to RGB in VideoFrame.copyTo()

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3767,9 +3767,8 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
     5. If `destination.byteLength` is less than |combinedLayout|'s [=combined
         buffer layout/allocationSize=], return a promise rejected with a
         {{TypeError}}.
-    6. If |options|.{{VideoFrameCopyToOptions/format}} does not equal
-        {{VideoFrame/[[format]]}} and |options|.{{VideoFrameCopyToOptions/format}}
-        is equal to one of {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} then:
+    6. If |options|.{{VideoFrameCopyToOptions/format}} is equal to one of
+        {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} then:
           1. Let |newOptions| be the result of running the <a>Clone Configuration</a>
                algorithm with |options|.
           2. Assign `undefined` to |newOptions|.{{VideoFrameCopyToOptions/format}}
@@ -3782,10 +3781,12 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
                algorithm with |options|.{{VideoFrameCopyToOptions/format}}, |rect|, and  `options.colorSpace`.
           7. Return the result of calling {{VideoFrame/copyTo()}} on |rgbFrame| with
                |destination| and |newOptions|.
-    7. Let |p| be a new {{Promise}}.
-    8. Let |copyStepsQueue| be the result of starting a new [=parallel queue=].
-    9. Let |planeLayouts| be a new [=list=].
-    10. Enqueue the following steps to |copyStepsQueue|:
+    7. Otherwise, if |options|.{{VideoFrameCopyToOptions/format}} is not `undefined` or `null`
+        throw a {{NotSupportedError}} {{DOMException}}.
+    8. Let |p| be a new {{Promise}}.
+    9. Let |copyStepsQueue| be the result of starting a new [=parallel queue=].
+    10. Let |planeLayouts| be a new [=list=].
+    11. Enqueue the following steps to |copyStepsQueue|:
         1. Let resource be the [=media resource=] referenced by
             [[resource reference]].
         2. Let |numPlanes| be the number of planes as defined by
@@ -3822,7 +3823,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
             10. Increment |planeIndex| by `1`.
             11. Append |layout| to |planeLayouts|.
         5. [=Queue a task=] to resolve |p| with |planeLayouts|.
-    11. Return |p|.
+    12. Return |p|.
 
 : <dfn method for=VideoFrame>clone()</dfn>
 :: Creates a new {{VideoFrame}} with a reference to the same
@@ -4328,9 +4329,9 @@ will enforce the following requirements:
     invalid to specify planes that overlap.
 : <dfn dict-member for=VideoFrameCopyToOptions>format</dfn>
 :: A {{VideoPixelFormat}} for the pixel data in the destination
-    {{BufferSource}}. Potential values are:
-    {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} and values of {{VideoFrame/format}}.
-    If unspecified or `null`, the {{VideoFrame/format}} is used.
+    {{BufferSource}}. Potential values are: {{RGBA}}, {{RGBX}}, {{BGRA}},
+    {{BGRX}}. If unspecified or `null`, the the destination
+    {{BufferSource}} will match {{VideoFrame/format}} .
 : <dfn dict-member for=VideoFrameCopyToOptions>colorSpace</dfn>
 :: A {{PredefinedColorSpace}} that <em class="rfc2119">SHALL</em> be used as
     a target color space for the pixel data in the destination

--- a/index.src.html
+++ b/index.src.html
@@ -3767,7 +3767,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
     5. If `destination.byteLength` is less than |combinedLayout|'s [=combined
         buffer layout/allocationSize=], return a promise rejected with a
         {{TypeError}}.
-    6. If |options|.{{VideoFrameCopyToOptions/format}} does not equal to
+    6. If |options|.{{VideoFrameCopyToOptions/format}} does not equal
         {{VideoFrame/[[format]]}} and |options|.{{VideoFrameCopyToOptions/format}}
         is equal to one of {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} then:
           1. Let |newOptions| be the result of running the <a>Clone Configuration</a>
@@ -4214,25 +4214,25 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
     2. Let |canvasSettings| be a new {{CanvasRenderingContext2DSettings}} with
         {{CanvasRenderingContext2DSettings/colorSpace}} set to |colorSpace|.
     3. Let |context| be the result of calling {{OffscreenCanvas/getContext()}}
-        on |canvas| with `"2d"` and |canvasSettings|
+        on |canvas| with `"2d"` and |canvasSettings|.
     3. Call {{CanvasDrawImage/drawImage()}} on |context| with
         `rect.x`, `rect.y`, `rect.width`, `rect.height`, `0`, `0`, `rect.width`,
         `rect.height`.
     4. Let |imageData| be the result of calling {{CanvasImageData/getImageData()}} with
         `0`, `0`, |rect.width|, |rect.height|.
     5. If |format| is equal to {{BGRA}} or {{BGRX}}:
-        1. Let |pixelIndex| be `0`
+        1. Let |pixelIndex| be `0`.
         2. While |pixelIndex| is less than `rect.width` multiplied by `rect.height`:
             1. Swap elements in |imageData|.{{ImageData/data}} at indexes `4 * pixelIndex`
                  and `4 * pixelIndex + 2`.
-            2. Increment |pixelIndex| by `1`
+            2. Increment |pixelIndex| by `1`.
     6. Let |init| be a new {{VideoFrameBufferInit}} constructed with
         {{VideoFrameBufferInit/format}} = |format|,
         {{VideoFrameBufferInit/codedWidth}} = `rect.width`,
-        {{VideoFrameBufferInit/codedHeight}} = `rect.height`
+        {{VideoFrameBufferInit/codedHeight}} = `rect.height`.
     7. Let |convertedFrame| be a new {{VideoFrame}} constructed with
-        |imageData|.{{ImageData/data}} and |init|
-    8. Return |convertedFrame|
+        |imageData|.{{ImageData/data}} and |init|.
+    8. Return |convertedFrame|.
 
 : <dfn for=VideoFrame>Copy VideoFrame metadata</dfn> (with |metadata|)
 :: 1. Let |metadataCopySerialized| be [$StructuredSerialize$](|metadata|).
@@ -4290,7 +4290,7 @@ value to {{ColorSpaceConversion/"none"}} disables color space conversion.
 
 VideoFrame CopyTo() Options {#videoframe-copyto-options}
 ------------------------------------------------------------
-Options to specify a rectangle of pixels to copy, their format and the offset
+Options to specify a rectangle of pixels to copy, their format, and the offset
 and stride of planes in the destination buffer.
 
 <xmp class='idl'>
@@ -4332,8 +4332,8 @@ will enforce the following requirements:
     {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} and values of {{VideoFrame/format}}.
     If unspecified or `null`, the {{VideoFrame/format}} is used.
 : <dfn dict-member for=VideoFrameCopyToOptions>colorSpace</dfn>
-:: A {{PredefinedColorSpace}} that <em class="rfc2119">SHALL</em> be used to as
-    a target color space for for the pixel data in the destination
+:: A {{PredefinedColorSpace}} that <em class="rfc2119">SHALL</em> be used as
+    a target color space for the pixel data in the destination
     {{BufferSource}}, but only if {{VideoFrameCopyToOptions/format}} is one of
     {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}}, otherwise it is ignored.
     If unspecified or `null`, {{srgb}} is used.

--- a/index.src.html
+++ b/index.src.html
@@ -4322,7 +4322,7 @@ will enforce the following requirements:
 : <dfn dict-member for=VideoFrameCopyToOptions>format</dfn>
 :: A {{VideoPixelFormat}} for the pixel data in the destination
     {{BufferSource}}. Potential values are: {{RGBA}}, {{RGBX}}, {{BGRA}},
-    {{BGRX}}. If it does not [=map/exist=], the the destination
+    {{BGRX}}. If it does not [=map/exist=], the destination
     {{BufferSource}} will be in the same format as {{VideoFrame/format}} .
 : <dfn dict-member for=VideoFrameCopyToOptions>colorSpace</dfn>
 :: A {{PredefinedColorSpace}} that <em class="rfc2119">MUST</em> be used as

--- a/index.src.html
+++ b/index.src.html
@@ -3748,8 +3748,8 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
 
 : <dfn method for=VideoFrame>copyTo(|destination|, |options|)</dfn>
 :: Asynchronously copies the planes of this frame into |destination| according
-    to |options|. The format of the data is specified by {{VideoFrameCopyToOptions/format}},
-    if present, otherwise {{VideoFrame/format}}.
+    to |options|. The format of the data is |options|.{{VideoFrameCopyToOptions/format}},
+    if it [=map/exists=] or [=this=] {{VideoFrame}}'s {{VideoFrame/format}} otherwise.
 
     NOTE: Promises that are returned by several calls to
         {{VideoFrame/copyTo()}} are not guaranteed to resolve in the order they
@@ -3777,12 +3777,10 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
                and |options|.{{VideoFrameCopyToOptions/colorSpace}}.
           4. Return the result of calling {{VideoFrame/copyTo()}} on |rgbFrame| with
                |destination| and |newOptions|.
-    7. Otherwise, if |options|.{{VideoFrameCopyToOptions/format}} is not `undefined` or `null`
-        return a promise rejected with a {{NotSupportedError}} {{DOMException}}.
-    8. Let |p| be a new {{Promise}}.
-    9. Let |copyStepsQueue| be the result of starting a new [=parallel queue=].
-    10. Let |planeLayouts| be a new [=list=].
-    11. Enqueue the following steps to |copyStepsQueue|:
+    7. Let |p| be a new {{Promise}}.
+    8. Let |copyStepsQueue| be the result of starting a new [=parallel queue=].
+    9. Let |planeLayouts| be a new [=list=].
+    10. Enqueue the following steps to |copyStepsQueue|:
         1. Let resource be the [=media resource=] referenced by
             [[resource reference]].
         2. Let |numPlanes| be the number of planes as defined by
@@ -3819,7 +3817,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
             10. Increment |planeIndex| by `1`.
             11. Append |layout| to |planeLayouts|.
         5. [=Queue a task=] to resolve |p| with |planeLayouts|.
-    12. Return |p|.
+    11. Return |p|.
 
 : <dfn method for=VideoFrame>clone()</dfn>
 :: Creates a new {{VideoFrame}} with a reference to the same
@@ -4064,7 +4062,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
     7. If |options|.{{VideoFrameCopyToOptions/layout}} [=map/exists=], assign
         its value to |optLayout|.
     8. Let |format| be `undefined`.
-    9. If |options|.{{VideoFrameCopyToOptions/format}} is `undefined`,
+    9. If |options|.{{VideoFrameCopyToOptions/format}} does not [=map/exist=],
         assign {{VideoFrame/[[format]]}} to |format|.
     10. Otherwise, if |options|.{{VideoFrameCopyToOptions/format}} is equal to
         one of {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}}, then assign
@@ -4324,14 +4322,14 @@ will enforce the following requirements:
 : <dfn dict-member for=VideoFrameCopyToOptions>format</dfn>
 :: A {{VideoPixelFormat}} for the pixel data in the destination
     {{BufferSource}}. Potential values are: {{RGBA}}, {{RGBX}}, {{BGRA}},
-    {{BGRX}}. If unspecified or `null`, the the destination
-    {{BufferSource}} will match {{VideoFrame/format}} .
+    {{BGRX}}. If it does not [=map/exist=], the the destination
+    {{BufferSource}} will be in the same format as {{VideoFrame/format}} .
 : <dfn dict-member for=VideoFrameCopyToOptions>colorSpace</dfn>
 :: A {{PredefinedColorSpace}} that <em class="rfc2119">MUST</em> be used as
     a target color space for the pixel data in the destination
     {{BufferSource}}, but only if {{VideoFrameCopyToOptions/format}} is one of
     {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}}, otherwise it is ignored.
-    If unspecified or `null`, {{srgb}} is used.
+    If it does not [=map/exist=], {{srgb}} is used.
 
 
 DOMRects in VideoFrame {#videoframe-domrect}

--- a/index.src.html
+++ b/index.src.html
@@ -38,6 +38,8 @@ spec:infra; type:dfn; text:enqueue
 spec: html; urlPrefix: https://html.spec.whatwg.org/multipage/;
     for: ImageBitmap;
         type: dfn; text: bitmap data; url: imagebitmap-and-animations.html#concept-imagebitmap-bitmap-data
+    for: ImageData
+        type: dfn; text: canvas pixel data; url: canvas.html#imagedata
     for: Canvas;
         type: dfn; text: Check the usability of the image argument; url: canvas.html#check-the-usability-of-the-image-argument
         type: dfn; text: is not origin-clean; url: canvas.html#the-image-argument-is-not-origin-clean
@@ -3745,8 +3747,8 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
 
 : <dfn method for=VideoFrame>copyTo(|destination|, |options|)</dfn>
 :: Asynchronously copies the planes of this frame into |destination| according
-    to |options|. The format of the data is the same as this {{VideoFrame}}'s
-    {{VideoFrame/format}}.
+    to |options|. The format of the data is specified by {{VideoFrameCopyToOptions/format}},
+    if present, or the same as {{VideoFrame/format}}.
 
     NOTE: Promises that are returned by several calls to
         {{VideoFrame/copyTo()}} are not guaranteed to resolve in the order they
@@ -3764,10 +3766,20 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
     5. If `destination.byteLength` is less than |combinedLayout|'s [=combined
         buffer layout/allocationSize=], return a promise rejected with a
         {{TypeError}}.
-    6. Let |p| be a new {{Promise}}.
-    7. Let |copyStepsQueue| be the result of starting a new [=parallel queue=].
-    8. Let |planeLayouts| be a new [=list=].
-    9. Enqueue the following steps to |copyStepsQueue|:
+    6. If `options.format` does not equal to {{VideoFrame/[[format]]}} and
+        `options.format` is equal to one of {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}}
+        then:
+          1. Let |serializedOptions| be [$StructuredSerialize$](|options|)
+          2. Let |newOptions| be [$StructuredDeserialize$](|serializedOptions|, [=the current Realm=]).
+          3. Set |newOptions.format| to `undefined`
+          4. Let |rgbFrame| be the result of running the [=VideoFrame/Convert to RGB frame=]
+               algorithm with `options.format`, `options.rect`, and  `options.colorSpace`.
+          5. Return the result of calling {{VideoFrame/copyTo()}} on |rgbFrame| with
+               |destination| and |newOptions|.
+    7. Let |p| be a new {{Promise}}.
+    8. Let |copyStepsQueue| be the result of starting a new [=parallel queue=].
+    9. Let |planeLayouts| be a new [=list=].
+    10. Enqueue the following steps to |copyStepsQueue|:
         1. Let resource be the [=media resource=] referenced by
             [[resource reference]].
         2. Let |numPlanes| be the number of planes as defined by
@@ -3804,7 +3816,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
             10. Increment |planeIndex| by `1`.
             11. Append |layout| to |planeLayouts|.
         5. [=Queue a task=] to resolve |p| with |planeLayouts|.
-    10. Return |p|.
+    11. Return |p|.
 
 : <dfn method for=VideoFrame>clone()</dfn>
 :: Creates a new {{VideoFrame}} with a reference to the same
@@ -4048,10 +4060,17 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
     6. Let |optLayout| be `undefined`.
     7. If |options|.{{VideoFrameCopyToOptions/layout}} [=map/exists=], assign
         its value to |optLayout|.
-    8. Let |combinedLayout| be the result of running the [=VideoFrame/Compute
-        Layout and Allocation Size=] algorithm with |parsedRect|,
-        {{VideoFrame/[[format]]}}, and |optLayout|.
-    9. Return |combinedLayout|.
+    8. Let |format| be `undefined`.
+    9. If |options|.{{VideoFrameCopyToOptions/format}} is `undefined`,
+        assign {{VideoFrame/[[format]]}} to |format|.
+    10. Otherwise, if |options|.{{VideoFrameCopyToOptions/format}} is equal to
+        one of {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}}, then assign
+        |options|.{{VideoFrameCopyToOptions/format}} to |format|,
+        otherwise return {{NotSupportedError}}.
+    11. Let |combinedLayout| be the result of running the [=VideoFrame/Compute
+        Layout and Allocation Size=] algorithm with |parsedRect|, |format|,
+        and |optLayout|.
+    12. Return |combinedLayout|.
 
 : <dfn for=VideoFrame>Verify Rect Offset Alignment</dfn> (with |format| and
     |rect|)
@@ -4183,10 +4202,36 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
             [=combined buffer layout/allocationSize=].
     9. Return |combinedLayout|.
 
+: <dfn for=VideoFrame>Convert to RGB frame</dfn> (with |format|, |rect| and |colorSpace|)
+ :: 1. Let |canvas| be a new {{OffscreenCanvas}} constructed with
+        |rect|.|width| and |rect|.|height|.
+    2. Let |canvasSettings| be a new {{CanvasRenderingContext2DSettings}} with
+        {{CanvasRenderingContext2DSettings/colorSpace}} set to |colorSpace|.
+    3. Let |context| be the result of calling {{OffscreenCanvas/getContext()}}
+        on |canvas| with `"2d"` and |canvasSettings|
+    3. Call {{CanvasDrawImage/drawImage()}} on |context| with
+        `rect.x`, `rect.y`, `rect.width`, `rect.height`, `0`, `0`, `rect.width`,
+        `rect.height`.
+    4. Let |imageData| be the result of calling {{CanvasImageData/getImageData()}} with
+        `0`, `0`, |rect.width|, |rect.height|.
+    5. If |format| is equal to {{BGRA}} or {{BGRX}}:
+        1. Let |pixelIndex| be `0`
+        2. While |pixelIndex| is less than `rect.width` multiplied by `rect.height`:
+            1. Swap items in |imageData|.{{ImageData/data}} at indexes `4 * pixelIndex`
+                 and `4 * pixelIndex + 2`.
+            2. Increment |pixelIndex| by `1`
+    6. Let |init| be a new {{VideoFrameBufferInit}} constructed with
+        {{VideoFrameBufferInit/format}} = |format|,
+        {{VideoFrameBufferInit/codedWidth}} = `rect.width`,
+        {{VideoFrameBufferInit/codedHeight}} = `rect.height`
+    7. Let |convertedFrame| be a new {{VideoFrame}} constructed with
+        |imageData|.{{ImageData/data}} and |init|
+    8. Return |convertedFrame|
+
 : <dfn for=VideoFrame>Copy VideoFrame metadata</dfn> (with |metadata|)
 :: 1. Let |metadataCopySerialized| be [$StructuredSerialize$](|metadata|).
     2. Let |metadataCopy| be [$StructuredDeserialize$](|metadataCopySerialized|, [=the current Realm=]).
-    3. return |metadataCopy|.
+    3. Return |metadataCopy|.
 
 The goal of this algorithm is to ensure that metadata owned by a {{VideoFrame}} is immutable.
 
@@ -4239,13 +4284,15 @@ value to {{ColorSpaceConversion/"none"}} disables color space conversion.
 
 VideoFrame CopyTo() Options {#videoframe-copyto-options}
 ------------------------------------------------------------
-Options to specify a rectangle of pixels to copy and the offset and stride of
-planes in the destination buffer.
+Options to specify a rectangle of pixels to copy, their format and the offset
+and stride of planes in the destination buffer.
 
 <xmp class='idl'>
 dictionary VideoFrameCopyToOptions {
   DOMRectInit rect;
   sequence<PlaneLayout> layout;
+  VideoPixelFormat format;
+  PredefinedColorSpace colorSpace;
 };
 </xmp>
 
@@ -4273,6 +4320,16 @@ will enforce the following requirements:
     to specify an offset and stride for each plane in the destination
     {{BufferSource}}. If unspecified, the planes will be tightly packed. It is
     invalid to specify planes that overlap.
+: <dfn dict-member for=VideoFrameCopyToOptions>format</dfn>
+:: A {{VideoPixelFormat}} for the pixel data in the destination
+    {{BufferSource}}. Explicity values cab be:
+    {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} and the same as {{VideoFrame/format}}.
+    If unspecified, the {{VideoFrame/format}} is used.
+: <dfn dict-member for=VideoFrameCopyToOptions>colorSpace</dfn>
+:: A {{PredefinedColorSpace}} that <em class="rfc2119">SHALL</em> be used to as
+    a target color space for for the pixel data in the destination
+    {{BufferSource}}.
+
 
 DOMRects in VideoFrame {#videoframe-domrect}
 --------------------------------------------

--- a/index.src.html
+++ b/index.src.html
@@ -3756,10 +3756,10 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
         were returned.
 
     When invoked, run these steps:
-    1. If {{platform object/[[Detached]]}} is `true`, throw an
-        {{InvalidStateError}} {{DOMException}}.
-    2. If {{VideoFrame/[[format]]}} is `null`, throw a {{NotSupportedError}}
-        {{DOMException}}.
+    1. If {{platform object/[[Detached]]}} is `true`, return a promise rejected
+        with a {{InvalidStateError}} {{DOMException}}.
+    2. If {{VideoFrame/[[format]]}} is `null`, return a promise rejected with a
+        {{NotSupportedError}} {{DOMException}}.
     3. Let |combinedLayout| be the result of running the [=Parse
         VideoFrameCopyToOptions=] algorithm with |options|.
     4. If |combinedLayout| is an exception, return a promise rejected with
@@ -3778,7 +3778,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
           4. Return the result of calling {{VideoFrame/copyTo()}} on |rgbFrame| with
                |destination| and |newOptions|.
     7. Otherwise, if |options|.{{VideoFrameCopyToOptions/format}} is not `undefined` or `null`
-        throw a {{NotSupportedError}} {{DOMException}}.
+        return a promise rejected with a {{NotSupportedError}} {{DOMException}}.
     8. Let |p| be a new {{Promise}}.
     9. Let |copyStepsQueue| be the result of starting a new [=parallel queue=].
     10. Let |planeLayouts| be a new [=list=].
@@ -4206,9 +4206,9 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
     9. Return |combinedLayout|.
 
 : <dfn for=VideoFrame>Convert to RGB frame</dfn> (with |frame|, |format| and |colorSpace|)
- :: 1. If |format| is not equal to one {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}},
-        throw a {{NotSupportedError}}
-    1. Let |convertedFrame| be a new {{VideoFrame}}, constructed as follows:
+ :: 1. This algorithm <em class="rfc2119">MUST</em> be called only if |format|
+        is equal to one of {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}}.
+    2. Let |convertedFrame| be a new {{VideoFrame}}, constructed as follows:
         1. Assign `false` to {{platform object/[[Detached]]}}.
         2. Assign |format| to {{VideoFrame/[[format]]}}.
         3. Let |width| be |frame|'s {{VideoFrame/[[visible width]]}}.
@@ -4227,7 +4227,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
             {{VideoFrame/[[resource reference]]}} into a color space and pixel
             format specified by |colorSpace| and |format| respectively.
         9. Assign the reference to |resource| to {{VideoFrame/[[resource reference]]}}
-    2. Return |convertedFrame|.
+    3. Return |convertedFrame|.
 
 : <dfn for=VideoFrame>Copy VideoFrame metadata</dfn> (with |metadata|)
 :: 1. Let |metadataCopySerialized| be [$StructuredSerialize$](|metadata|).

--- a/index.src.html
+++ b/index.src.html
@@ -4322,7 +4322,7 @@ will enforce the following requirements:
     invalid to specify planes that overlap.
 : <dfn dict-member for=VideoFrameCopyToOptions>format</dfn>
 :: A {{VideoPixelFormat}} for the pixel data in the destination
-    {{BufferSource}}. Explicit values cab be:
+    {{BufferSource}}. Explicit values can be:
     {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} or the same as {{VideoFrame/format}}.
     If unspecified, the {{VideoFrame/format}} is used.
 : <dfn dict-member for=VideoFrameCopyToOptions>colorSpace</dfn>

--- a/index.src.html
+++ b/index.src.html
@@ -30,6 +30,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 
 <pre class=link-defaults>
 spec:html; type:attribute; text:hidden
+spec:html; type:enum-value; text:srgb
 spec:infra; type:dfn; text:list
 spec:infra; type:dfn; text:enqueue
 </pre>
@@ -3766,15 +3767,20 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
     5. If `destination.byteLength` is less than |combinedLayout|'s [=combined
         buffer layout/allocationSize=], return a promise rejected with a
         {{TypeError}}.
-    6. If `options.format` does not equal to {{VideoFrame/[[format]]}} and
-        `options.format` is equal to one of {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}}
-        then:
-          1. Let |serializedOptions| be [$StructuredSerialize$](|options|)
-          2. Let |newOptions| be [$StructuredDeserialize$](|serializedOptions|, [=the current Realm=]).
-          3. Set |newOptions.format| to `undefined`
-          4. Let |rgbFrame| be the result of running the [=VideoFrame/Convert to RGB frame=]
-               algorithm with `options.format`, `options.rect`, and  `options.colorSpace`.
-          5. Return the result of calling {{VideoFrame/copyTo()}} on |rgbFrame| with
+    6. If |options|.{{VideoFrameCopyToOptions/format}} does not equal to
+        {{VideoFrame/[[format]]}} and |options|.{{VideoFrameCopyToOptions/format}}
+        is equal to one of {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} then:
+          1. Let |newOptions| be the result of running the <a>Clone Configuration</a>
+               algorithm with |options|.
+          2. Assign `undefined` to |newOptions|.{{VideoFrameCopyToOptions/format}}
+               and |newOptions|.{{VideoFrameCopyToOptions/rect}}.
+          3. Let |rect| be `undefined`.
+          4. If |options|.{{VideoFrameCopyToOptions/rect}} [=map/exists=], assign the
+               value of |options|.{{VideoFrameCopyToOptions/rect}} to |rect|.
+          5. Otherwise, assign the value of {{VideoFrame/visibleRect}} to |rect|.
+          6. Let |rgbFrame| be the result of running the [=VideoFrame/Convert to RGB frame=]
+               algorithm with |options|.{{VideoFrameCopyToOptions/format}}, |rect|, and  `options.colorSpace`.
+          7. Return the result of calling {{VideoFrame/copyTo()}} on |rgbFrame| with
                |destination| and |newOptions|.
     7. Let |p| be a new {{Promise}}.
     8. Let |copyStepsQueue| be the result of starting a new [=parallel queue=].
@@ -4322,13 +4328,13 @@ will enforce the following requirements:
     invalid to specify planes that overlap.
 : <dfn dict-member for=VideoFrameCopyToOptions>format</dfn>
 :: A {{VideoPixelFormat}} for the pixel data in the destination
-    {{BufferSource}}. Explicit values can be:
-    {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} or the same as {{VideoFrame/format}}.
+    {{BufferSource}}. Potential values are:
+    {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} and values of {{VideoFrame/format}}.
     If unspecified, the {{VideoFrame/format}} is used.
 : <dfn dict-member for=VideoFrameCopyToOptions>colorSpace</dfn>
 :: A {{PredefinedColorSpace}} that <em class="rfc2119">SHALL</em> be used to as
     a target color space for for the pixel data in the destination
-    {{BufferSource}}.
+    {{BufferSource}}. If unspecified, {{srgb}} is used.
 
 
 DOMRects in VideoFrame {#videoframe-domrect}

--- a/index.src.html
+++ b/index.src.html
@@ -4330,11 +4330,13 @@ will enforce the following requirements:
 :: A {{VideoPixelFormat}} for the pixel data in the destination
     {{BufferSource}}. Potential values are:
     {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} and values of {{VideoFrame/format}}.
-    If unspecified, the {{VideoFrame/format}} is used.
+    If unspecified or `null`, the {{VideoFrame/format}} is used.
 : <dfn dict-member for=VideoFrameCopyToOptions>colorSpace</dfn>
 :: A {{PredefinedColorSpace}} that <em class="rfc2119">SHALL</em> be used to as
     a target color space for for the pixel data in the destination
-    {{BufferSource}}. If unspecified, {{srgb}} is used.
+    {{BufferSource}}, but only if {{VideoFrameCopyToOptions/format}} is one of
+    {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}}, otherwise it is ignored.
+    If unspecified or `null`, {{srgb}} is used.
 
 
 DOMRects in VideoFrame {#videoframe-domrect}

--- a/index.src.html
+++ b/index.src.html
@@ -3748,7 +3748,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
 : <dfn method for=VideoFrame>copyTo(|destination|, |options|)</dfn>
 :: Asynchronously copies the planes of this frame into |destination| according
     to |options|. The format of the data is specified by {{VideoFrameCopyToOptions/format}},
-    if present, or the same as {{VideoFrame/format}}.
+    if present, otherwise {{VideoFrame/format}}.
 
     NOTE: Promises that are returned by several calls to
         {{VideoFrame/copyTo()}} are not guaranteed to resolve in the order they
@@ -4217,7 +4217,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
     5. If |format| is equal to {{BGRA}} or {{BGRX}}:
         1. Let |pixelIndex| be `0`
         2. While |pixelIndex| is less than `rect.width` multiplied by `rect.height`:
-            1. Swap items in |imageData|.{{ImageData/data}} at indexes `4 * pixelIndex`
+            1. Swap elements in |imageData|.{{ImageData/data}} at indexes `4 * pixelIndex`
                  and `4 * pixelIndex + 2`.
             2. Increment |pixelIndex| by `1`
     6. Let |init| be a new {{VideoFrameBufferInit}} constructed with
@@ -4322,8 +4322,8 @@ will enforce the following requirements:
     invalid to specify planes that overlap.
 : <dfn dict-member for=VideoFrameCopyToOptions>format</dfn>
 :: A {{VideoPixelFormat}} for the pixel data in the destination
-    {{BufferSource}}. Explicity values cab be:
-    {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} and the same as {{VideoFrame/format}}.
+    {{BufferSource}}. Explicit values cab be:
+    {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} or the same as {{VideoFrame/format}}.
     If unspecified, the {{VideoFrame/format}} is used.
 : <dfn dict-member for=VideoFrameCopyToOptions>colorSpace</dfn>
 :: A {{PredefinedColorSpace}} that <em class="rfc2119">SHALL</em> be used to as

--- a/index.src.html
+++ b/index.src.html
@@ -3771,15 +3771,11 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
         {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}} then:
           1. Let |newOptions| be the result of running the <a>Clone Configuration</a>
                algorithm with |options|.
-          2. Assign `undefined` to |newOptions|.{{VideoFrameCopyToOptions/format}}
-               and |newOptions|.{{VideoFrameCopyToOptions/rect}}.
-          3. Let |rect| be `undefined`.
-          4. If |options|.{{VideoFrameCopyToOptions/rect}} [=map/exists=], assign the
-               value of |options|.{{VideoFrameCopyToOptions/rect}} to |rect|.
-          5. Otherwise, assign the value of {{VideoFrame/visibleRect}} to |rect|.
-          6. Let |rgbFrame| be the result of running the [=VideoFrame/Convert to RGB frame=]
-               algorithm with |options|.{{VideoFrameCopyToOptions/format}}, |rect|, and  `options.colorSpace`.
-          7. Return the result of calling {{VideoFrame/copyTo()}} on |rgbFrame| with
+          2. Assign `undefined` to |newOptions|.{{VideoFrameCopyToOptions/format}}.
+          3. Let |rgbFrame| be the result of running the [=VideoFrame/Convert to RGB frame=]
+               algorithm with [=this=], |options|.{{VideoFrameCopyToOptions/format}},
+               and |options|.{{VideoFrameCopyToOptions/colorSpace}}.
+          4. Return the result of calling {{VideoFrame/copyTo()}} on |rgbFrame| with
                |destination| and |newOptions|.
     7. Otherwise, if |options|.{{VideoFrameCopyToOptions/format}} is not `undefined` or `null`
         throw a {{NotSupportedError}} {{DOMException}}.
@@ -4209,35 +4205,29 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
             [=combined buffer layout/allocationSize=].
     9. Return |combinedLayout|.
 
-: <dfn for=VideoFrame>Convert to RGB frame</dfn> (with |format|, |rect| and |colorSpace|)
- :: 1. Let |canvas| be a new {{OffscreenCanvas}} constructed with
-        |rect|.|width| and |rect|.|height|.
-    2. Let |canvasSettings| be a new {{CanvasRenderingContext2DSettings}} with
-        {{CanvasRenderingContext2DSettings/colorSpace}} set to |colorSpace|.
-    3. Let |context| be the result of calling {{OffscreenCanvas/getContext()}}
-        on |canvas| with `"2d"` and |canvasSettings|.
-    3. Call {{CanvasDrawImage/drawImage()}} on |context| with
-        `rect.x`, `rect.y`, `rect.width`, `rect.height`, `0`, `0`, `rect.width`,
-        `rect.height`.
-    4. Let |imageData| be the result of calling {{CanvasImageData/getImageData()}} with
-        `0`, `0`, |rect.width|, |rect.height|.
-    5. If |format| is equal to {{BGRA}} or {{BGRX}}:
-        1. Let |pixelIndex| be `0`.
-        2. While |pixelIndex| is less than `rect.width` multiplied by `rect.height`:
-            1. Swap elements in |imageData|.{{ImageData/data}} at indexes `4 * pixelIndex`
-                 and `4 * pixelIndex + 2`.
-            2. Increment |pixelIndex| by `1`.
-    6. Let |init| be a new {{VideoFrameBufferInit}} constructed with
-        {{VideoFrameBufferInit/format}} = |format|,
-        {{VideoFrameBufferInit/codedWidth}} = `rect.width`,
-        {{VideoFrameBufferInit/codedHeight}} = `rect.height`.
-    7. Let |convertedFrame| be a new {{VideoFrame}} constructed with
-        |imageData|.{{ImageData/data}} and |init|.
-    8. Return |convertedFrame|.
-
-NOTE: User Agents don't have to execute the exact steps of this algorithm
-(e.g. create an {{OffscreenCanvas}}) as long as the {{VideoFrame}} returned by
-the algorithm is equal to the {{VideoFrame}} created via these steps.
+: <dfn for=VideoFrame>Convert to RGB frame</dfn> (with |frame|, |format| and |colorSpace|)
+ :: 1. If |format| is not equal to one {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}},
+        throw a {{NotSupportedError}}
+    1. Let |convertedFrame| be a new {{VideoFrame}}, constructed as follows:
+        1. Assign `false` to {{platform object/[[Detached]]}}.
+        2. Assign |format| to {{VideoFrame/[[format]]}}.
+        3. Let |width| be |frame|'s {{VideoFrame/[[visible width]]}}.
+        4. Let |height| be |frame|'s {{VideoFrame/[[visible height]]}}.
+        5. Assign |width|, |height|, 0, 0, |width|, |height|, |width|, and
+            |height| to {{VideoFrame/[[coded width]]}},
+            {{VideoFrame/[[coded height]]}}, {{VideoFrame/[[visible left]]}},
+            {{VideoFrame/[[visible top]]}}, {{VideoFrame/[[visible width]]}},
+            and {{VideoFrame/[[visible height]]}} respectively.
+	      6. Assign |frame|'s {{VideoFrame/[[duration]]}} and |frame|'s
+            {{VideoFrame/[[timestamp]]}} to {{VideoFrame/[[duration]]}} and
+            {{VideoFrame/[[timestamp]]}} respectively.
+        7. Assign |colorSpace| to {{VideoFrame/[[color space]]}}.
+        8. Let |resource| be a new [=media resource=] containing the result of
+            conversion of [=media resource=] referenced by |frame|'s
+            {{VideoFrame/[[resource reference]]}} into a color space and pixel
+            format specified by |colorSpace| and |format| respectively.
+        9. Assign the reference to |resource| to {{VideoFrame/[[resource reference]]}}
+    2. Return |convertedFrame|.
 
 : <dfn for=VideoFrame>Copy VideoFrame metadata</dfn> (with |metadata|)
 :: 1. Let |metadataCopySerialized| be [$StructuredSerialize$](|metadata|).

--- a/index.src.html
+++ b/index.src.html
@@ -4235,6 +4235,10 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
         |imageData|.{{ImageData/data}} and |init|.
     8. Return |convertedFrame|.
 
+NOTE: User Agents don't have to execute the exact steps of this algorithm
+(e.g. create an {{OffscreenCanvas}}) as long as the {{VideoFrame}} returned by
+the algorithm is equal to the {{VideoFrame}} created via these steps.
+
 : <dfn for=VideoFrame>Copy VideoFrame metadata</dfn> (with |metadata|)
 :: 1. Let |metadataCopySerialized| be [$StructuredSerialize$](|metadata|).
     2. Let |metadataCopy| be [$StructuredDeserialize$](|metadataCopySerialized|, [=the current Realm=]).
@@ -4333,7 +4337,7 @@ will enforce the following requirements:
     {{BGRX}}. If unspecified or `null`, the the destination
     {{BufferSource}} will match {{VideoFrame/format}} .
 : <dfn dict-member for=VideoFrameCopyToOptions>colorSpace</dfn>
-:: A {{PredefinedColorSpace}} that <em class="rfc2119">SHALL</em> be used as
+:: A {{PredefinedColorSpace}} that <em class="rfc2119">MUST</em> be used as
     a target color space for the pixel data in the destination
     {{BufferSource}}, but only if {{VideoFrameCopyToOptions/format}} is one of
     {{RGBA}}, {{RGBX}}, {{BGRA}}, {{BGRX}}, otherwise it is ignored.


### PR DESCRIPTION
This change should address the [issue](https://github.com/w3c/webcodecs/issues/92) of pixel format conversion in `VideoFrame.copyTo()`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Djuffin/webcodecs/pull/754.html" title="Last updated on Apr 16, 2024, 8:43 AM UTC (0df4aee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/754/871ccb3...Djuffin:0df4aee.html" title="Last updated on Apr 16, 2024, 8:43 AM UTC (0df4aee)">Diff</a>