### PR TITLE
Extend EncodedVideoChunkMetadata for Spatial Scalability

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1713,13 +1713,13 @@ dictionary EncodedVideoChunkMetadata {
   VideoDecoderConfig decoderConfig;
   SvcOutputMetadata svc;
   BufferSource alphaSideData;
+  unsigned long long frameId;
+  sequence <unsigned long long> dependencies;
 };
 
 dictionary SvcOutputMetadata {
   unsigned long temporalLayerId;
   unsigned long spatialLayerId;
-  unsigned long long frameId;
-  sequence <unsigned long long> dependencies;
 };
 </xmp>
 

--- a/index.src.html
+++ b/index.src.html
@@ -1648,28 +1648,29 @@ Algorithms {#videoencoder-algorithms}
             2. Assign |outputConfig| to
                 {{VideoEncoder/[[active output config]]}}.
         7. If |encoderConfig|.{{VideoEncoderConfig/scalabilityMode}}
-            describes multiple [=temporal layers=]:
-            1. Let |svc| be a new {{SvcOutputMetadata}} instance.
-            2. Let |temporal_layer_id| be the zero-based index describing the
-                temporal layer for |output|.
-            3. Assign |temporal_layer_id| to
-                |svc|.{{SvcOutputMetadata/temporalLayerId}}.
-            4. Assign |svc| to
-                |chunkMetadata|.{{EncodedVideoChunkMetadata/svc}}.
+            describes multiple [=temporal layers=] or [=spatial layers=]:
+                  1. Let |svc| be a new {{SvcOutputMetadata}} instance.
         8. If |encoderConfig|.{{VideoEncoderConfig/scalabilityMode}}
+            describes multiple [=temporal layers=]:
+            1. Let |temporal_layer_id| be the zero-based index describing the
+                temporal layer for |output|.
+            2. Assign |temporal_layer_id| to
+                |svc|.{{SvcOutputMetadata/temporalLayerId}}.
+        9. If |encoderConfig|.{{VideoEncoderConfig/scalabilityMode}}
             describes multiple [=spatial layers=]:
-            1. Let |svc| be a new {{SvcOutputMetadata}} instance.
-            2. Let |spatial_layer_id| be the zero-based index describing the
+            1. Let |spatial_layer_id| be the zero-based index describing the
                 spatial layer for |output|.
-            3. Assign |spatial_layer_id| to
+            2. Assign |spatial_layer_id| to
                 |svc|.{{SvcOutputMetadata/spatialLayerId}}.
-            4. Assign |svc| to
+       10. If |encoderConfig|.{{VideoEncoderConfig/scalabilityMode}}
+            describes multiple [=temporal layers=] or [=spatial layers=]:
+            1. Assign |svc| to
                 |chunkMetadata|.{{EncodedVideoChunkMetadata/svc}}.
-        9. If |encoderConfig|.{{VideoEncoderConfig/alpha}} is set to `"keep"`:
+       11. If |encoderConfig|.{{VideoEncoderConfig/alpha}} is set to `"keep"`:
             1. Let |alphaSideData| be the encoded alpha data in |output|.
             2. Assign |alphaSideData| to
                 |chunkMetadata|.{{EncodedVideoChunkMetadata/alphaSideData}}.
-       10. Invoke {{VideoEncoder/[[output callback]]}} with |chunk| and
+       12. Invoke {{VideoEncoder/[[output callback]]}} with |chunk| and
             |chunkMetadata|.
   </dd>
   <dt><dfn>Reset VideoEncoder</dfn> (with |exception|)</dt>

--- a/index.src.html
+++ b/index.src.html
@@ -1736,6 +1736,12 @@ dictionary SvcOutputMetadata {
 :: A {{BufferSource}} that contains the {{EncodedVideoChunk}}'s extra alpha
     channel data.
 
+: <dfn dict-member for= EncodedVideoChunkMetadat>frameId</dfn>
+:: A number that identifies the associated {{EncodedVideoChunk}}.
+
+: <dfn dict-member for= EncodedVideoChunkMetadat>dependencies</dfn>
+:: A sequence containing the {{frameId}} values that the associated {{EncodedVideoChunk}} depends on.
+
 : <dfn dict-member for=SvcOutputMetadata>temporalLayerId</dfn>
 :: A number that identifies the [=temporal layer=] for the associated
     {{EncodedVideoChunk}}.
@@ -1743,13 +1749,6 @@ dictionary SvcOutputMetadata {
 : <dfn dict-member for=SvcOutputMetadata>spatialLayerId</dfn>
 :: A number that identifies the [=spatial layer=] for the associated
     {{EncodedVideoChunk}}.
-
-: <dfn dict-member for=SvcOutputMetadata>frameId</dfn>
-:: A number that identifies the associated {{EncodedVideoChunk}}.
-
-
-: <dfn dict-member for=SvcOutputMetadata>dependencies</dfn>
-:: A sequence containing the {{frameId}} values that the associated {{EncodedVideoChunk}} depends on.
       
 Configurations{#configurations}
 ===============================

--- a/index.src.html
+++ b/index.src.html
@@ -133,6 +133,10 @@ Definitions {#definitions}
 :: A grouping of {{EncodedVideoChunk}}s whose timestamp cadence produces a
     particular framerate. See {{VideoEncoderConfig/scalabilityMode}}.
 
+: <dfn>Spatial Layer</dfn>
+:: A grouping of {{EncodedVideoChunk}}s which produces a particular
+    resolution. See {{VideoEncoderConfig/scalabilityMode}}.
+
 : <dfn>Progressive Image</dfn>
 :: An image that supports decoding to multiple levels of detail, with lower
     levels becoming available while the encoded data is not yet fully buffered.
@@ -1652,11 +1656,20 @@ Algorithms {#videoencoder-algorithms}
                 |svc|.{{SvcOutputMetadata/temporalLayerId}}.
             4. Assign |svc| to
                 |chunkMetadata|.{{EncodedVideoChunkMetadata/svc}}.
-        8. If |encoderConfig|.{{VideoEncoderConfig/alpha}} is set to `"keep"`:
+        8. If |encoderConfig|.{{VideoEncoderConfig/scalabilityMode}}
+            describes multiple [=spatial layers=]:
+            1. Let |svc| be a new {{SvcOutputMetadata}} instance.
+            2. Let |spatial_layer_id| be the zero-based index describing the
+                spatial layer for |output|.
+            3. Assign |spatial_layer_id| to
+                |svc|.{{SvcOutputMetadata/spatialLayerId}}.
+            4. Assign |svc| to
+                |chunkMetadata|.{{EncodedVideoChunkMetadata/svc}}.
+        9. If |encoderConfig|.{{VideoEncoderConfig/alpha}} is set to `"keep"`:
             1. Let |alphaSideData| be the encoded alpha data in |output|.
             2. Assign |alphaSideData| to
                 |chunkMetadata|.{{EncodedVideoChunkMetadata/alphaSideData}}.
-        9. Invoke {{VideoEncoder/[[output callback]]}} with |chunk| and
+       10. Invoke {{VideoEncoder/[[output callback]]}} with |chunk| and
             |chunkMetadata|.
   </dd>
   <dt><dfn>Reset VideoEncoder</dfn> (with |exception|)</dt>
@@ -1704,6 +1717,9 @@ dictionary EncodedVideoChunkMetadata {
 
 dictionary SvcOutputMetadata {
   unsigned long temporalLayerId;
+  unsigned long spatialLayerId;
+  unsigned long long frameId;
+  sequence <unsigned long long> dependencies;
 };
 </xmp>
 
@@ -1723,7 +1739,17 @@ dictionary SvcOutputMetadata {
 :: A number that identifies the [=temporal layer=] for the associated
     {{EncodedVideoChunk}}.
 
+: <dfn dict-member for=SvcOutputMetadata>spatialLayerId</dfn>
+:: A number that identifies the [=spatial layer=] for the associated
+    {{EncodedVideoChunk}}.
 
+: <dfn dict-member for=SvcOutputMetadata>frameId</dfn>
+:: A number that identifies the associated {{EncodedVideoChunk}}.
+
+
+: <dfn dict-member for=SvcOutputMetadata>dependencies</dfn>
+:: A sequence containing the {{frameId}} values that the associated {{EncodedVideoChunk}} depends on.
+      
 Configurations{#configurations}
 ===============================
 


### PR DESCRIPTION
Fixes #619

Rebase and update of PR #654

Related: https://github.com/w3c/webrtc-encoded-transform/issues/220


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 9, 2024, 10:27 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebcodecs%2F9efde67f1de0fdf0194f96bc8cb8f1eeb9197d80%2Findex.src.html&md-warning=not%20ready)

```
Error running preprocessor, returned code: 2.
FATAL ERROR: Couldn't find target frameId 'dict-member':
&lt;span data-dict-member-info="" for="EncodedVideoChunkMetadat/frameId">&lt;/span>
 ✘  Did not generate, due to errors exceeding the allowed error level.
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webcodecs%23756.)._
</details>
