### PR TITLE
Fix typo in Opus codec registration

### DIFF
--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -71,7 +71,7 @@ If the bitstream is in {{OpusBitstreamFormat/ogg}} format,
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-{{AudioDecoderConfig/description}} can optionally set to an Identification
+{{AudioDecoderConfig/description}} can be optionally set to an Identification
 Header, described in section 5.1 of [[OPUS-IN-OGG]].
 
 If a {{AudioDecoderConfig/description}} has been set, the bistream is assumed


### PR DESCRIPTION
This PR fixes a minor typo in the Opus codec registration.