### PR TITLE
Clarify VideoEncoderConfig.contentHint

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -52,6 +52,7 @@ spec: webrtc-svc; urlPrefix: https://www.w3.org/TR/webrtc-svc/
 
 spec: mst-content-hint; urlPrefix: https://www.w3.org/TR/mst-content-hint/
     type: dfn; text: video content hints; url:#video-content-hints
+    type: dfn; text: audio content hints; url:#audio-content-hints
 
 spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     type: dfn; text: the current Realm; url: #current-realm
@@ -2051,6 +2052,7 @@ dictionary AudioEncoderConfig {
   [EnforceRange] unsigned long numberOfChannels;
   [EnforceRange] unsigned long long bitrate;
   BitrateMode bitrateMode = "variable";
+  DOMString contentHint;
 };
 </xmp>
 
@@ -2089,6 +2091,29 @@ run these steps:
     NOTE: Not all audio codecs support specific {{BitrateMode}}s, Authors are
     encouraged to check by calling {{AudioEncoder/isConfigSupported()}} with
     |config|.
+  </dd>
+  <dt><dfn dict-member for=AudioEncoderConfig>contentHint</dfn></dt>
+  <dd>
+    An encoding [=audio content hint=] as defined by [[mst-content-hint]].
+
+    The User Agent <em class="rfc2119">MAY</em> use this hint to set
+    expectations about incoming {{AudioData}} and to improve encoding quality.
+    If using this hint:
+      - The User Agent <em class="rfc2119">MUST</em> respect other explicitly
+        set encoding options when configuring the encoder, whether they are
+        codec-specific encoding options or not.
+      - The User Agent <em class="rfc2119">SHOULD</em> make a best-effort
+        attempt to use additional configuration options to improve encoding
+        quality, according to the goals defined by the corresponding
+        [=audio content hint=].
+
+    NOTE: Some encoder options are implementation specific, and mappings between
+        {{AudioEncoderConfig/contentHint}} and those options cannot be
+        prescribed.
+
+    The User Agent <em class="rfc2119">MUST NOT</em> refuse the configuration
+    if it doesn't support this content hint.
+    See {{AudioEncoder/isConfigSupported()}}.
   </dd>
 </dl>
 
@@ -2233,13 +2258,22 @@ To check if a {{VideoEncoderConfig}} is a <dfn>valid VideoEncoderConfig</dfn>,
 
     The User Agent <em class="rfc2119">MAY</em> use this hint to set
     expectations about incoming {{VideoFrame}}s and to improve encoding quality.
+    If using this hint:
+      - The User Agent <em class="rfc2119">MUST</em> respect other explicitly
+        set encoding options when configuring the encoder, whether they are
+        codec-specific encoding options or not.
+      - The User Agent <em class="rfc2119">SHOULD</em> make a best-effort
+        attempt to use additional configuration options to improve encoding
+        quality, according to the goals defined by the corresponding
+        [=video content hint=].
+
+    NOTE: Some encoder options are implementation specific, and mappings between
+        {{VideoEncoderConfig/contentHint}} and those options cannot be
+        prescribed.
 
     The User Agent <em class="rfc2119">MUST NOT</em> refuse the configuration
     if it doesn't support this content hint.
     See {{VideoEncoder/isConfigSupported()}}.
-
-    NOTE: Any codec-specific encoding options take precedence over
-      {{contentHint}}.
   </dd>
 
 </dl>

--- a/index.src.html
+++ b/index.src.html
@@ -52,7 +52,6 @@ spec: webrtc-svc; urlPrefix: https://www.w3.org/TR/webrtc-svc/
 
 spec: mst-content-hint; urlPrefix: https://www.w3.org/TR/mst-content-hint/
     type: dfn; text: video content hints; url:#video-content-hints
-    type: dfn; text: audio content hints; url:#audio-content-hints
 
 spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
     type: dfn; text: the current Realm; url: #current-realm
@@ -2052,7 +2051,6 @@ dictionary AudioEncoderConfig {
   [EnforceRange] unsigned long numberOfChannels;
   [EnforceRange] unsigned long long bitrate;
   BitrateMode bitrateMode = "variable";
-  DOMString contentHint;
 };
 </xmp>
 
@@ -2091,29 +2089,6 @@ run these steps:
     NOTE: Not all audio codecs support specific {{BitrateMode}}s, Authors are
     encouraged to check by calling {{AudioEncoder/isConfigSupported()}} with
     |config|.
-  </dd>
-  <dt><dfn dict-member for=AudioEncoderConfig>contentHint</dfn></dt>
-  <dd>
-    An encoding [=audio content hint=] as defined by [[mst-content-hint]].
-
-    The User Agent <em class="rfc2119">MAY</em> use this hint to set
-    expectations about incoming {{AudioData}} and to improve encoding quality.
-    If using this hint:
-      - The User Agent <em class="rfc2119">MUST</em> respect other explicitly
-        set encoding options when configuring the encoder, whether they are
-        codec-specific encoding options or not.
-      - The User Agent <em class="rfc2119">SHOULD</em> make a best-effort
-        attempt to use additional configuration options to improve encoding
-        quality, according to the goals defined by the corresponding
-        [=audio content hint=].
-
-    NOTE: Some encoder options are implementation specific, and mappings between
-        {{AudioEncoderConfig/contentHint}} and those options cannot be
-        prescribed.
-
-    The User Agent <em class="rfc2119">MUST NOT</em> refuse the configuration
-    if it doesn't support this content hint.
-    See {{AudioEncoder/isConfigSupported()}}.
   </dd>
 </dl>
 


### PR DESCRIPTION
Fixes #735, addresses comments from #758.

This PR removes the note from `VideoEncoderConfig.contentHint` and forces User Agent to respect other explicitly set encoder options.

It also adds an equivalent `AudioEncoderConfig.contentHint` section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tguilbert-google/webcodecs/pull/759.html" title="Last updated on Feb 5, 2024, 10:31 PM UTC (0795078)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/759/21e4a15...tguilbert-google:0795078.html" title="Last updated on Feb 5, 2024, 10:31 PM UTC (0795078)">Diff</a>