### PR TITLE
Export Close VideoFrame as it is used in mediacapture-transform spec

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4006,7 +4006,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
             in |clone|.
     2. Return |clone|.
 
-: <dfn>Close VideoFrame</dfn> (with |frame|)
+: <dfn export>Close VideoFrame</dfn> (with |frame|)
 :: 1. Assign `null` to |frame|'s {{VideoFrame/[[resource reference]]}}.
     2. Assign `true` to |frame|'s {{platform object/[[Detached]]}}.
     3. Assign `null` to |frame|'s {{VideoFrame/format}}.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webcodecs/pull/763.html" title="Last updated on Jan 29, 2024, 9:11 AM UTC (4b530f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/763/21e4a15...youennf:4b530f5.html" title="Last updated on Jan 29, 2024, 9:11 AM UTC (4b530f5)">Diff</a>