### PR TITLE
{Audio,Video}DecoderConfig with detached description are invalid

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1916,7 +1916,9 @@ To check if an {{AudioDecoderConfig}} is a <dfn export>valid AudioDecoderConfig<
 1. If {{AudioDecoderConfig/codec}} is empty after
     [=strip leading and trailing ASCII whitespace|stripping leading and trailing ASCII whitespace=],
     return `false`.
-2. Return `true`.
+2. If the result of running  IsDetachedBuffer (described in
+    [[!ECMASCRIPT]]) on {{AudioDecoderConfig/description}} is `true`, return `false`.
+3. Return `true`.
 
 <dl>
   <dt><dfn dict-member for=AudioDecoderConfig>codec</dfn></dt>
@@ -1970,7 +1972,9 @@ run these steps:
     return `false`.
 5. If {{VideoDecoderConfig/displayAspectWidth}} = 0 or
     {{VideoDecoderConfig/displayAspectHeight}} = 0, return `false`.
-6. Return `true`.
+6. If the result of running  IsDetachedBuffer (described in
+    [[!ECMASCRIPT]]) on {{VideoDecoderConfig/description}} is `true`, return `false`.
+7. Return `true`.
 
 <dl>
   <dt><dfn dict-member for=VideoDecoderConfig>codec</dfn></dt>
@@ -5360,7 +5364,7 @@ run these steps:
     [=ReadableStream/disturbed=] or [=ReadableStream/locked=], return `false`.
 3. If |data| is of type {{BufferSource}}:
     1. If the result of running  IsDetachedBuffer (described in
-        [[!ECMASCRIPT]]) on |data| is `false`, return `false`.
+        [[!ECMASCRIPT]]) on |data| is `true`, return `false`.
     2. If |data| [=list/is empty=], return `false`.
 4. If {{ImageDecoderInit/desiredWidth}} [=map/exists=] and
     {{ImageDecoderInit/desiredHeight}} does not exist, return `false`.


### PR DESCRIPTION
This is what Chromium (at least) does. This means isConfigSupported and configure will now throw if description has been detached.

This also fixes a bug in the ImageDecoder version of this.

This fixes #762.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/764.html" title="Last updated on Jan 31, 2024, 10:26 AM UTC (250f7d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/764/9e0f22e...250f7d8.html" title="Last updated on Jan 31, 2024, 10:26 AM UTC (250f7d8)">Diff</a>