### PR TITLE
In the VideoFrame buffer constructor, init.layout, not options.layout

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3530,7 +3530,7 @@ dictionary VideoFrameMetadata {
         |init|.{{VideoFrameBufferInit/format}}.
 6. If |parsedRect| is an exception, return |parsedRect|.
 7. Let |optLayout| be `undefined`.
-8. If |options|.{{VideoFrameBufferInit/layout}} [=map/exists=], assign its value
+8. If |init|.{{VideoFrameBufferInit/layout}} [=map/exists=], assign its value
     to |optLayout|.
 9. Let |combinedLayout| be the result of running the [=VideoFrame/Compute
     Layout and Allocation Size=] algorithm with |parsedRect|,


### PR DESCRIPTION
In the steps for the VideoFrame constructor using a buffer, it specifies to use `options.layout`. But, there is no `options`; it's `init.layout`. This is presumably just a typo from copying from copyTo.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Yahweasel/webcodecs/pull/769.html" title="Last updated on Feb 27, 2024, 10:06 PM UTC (3728cff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/769/e979025...Yahweasel:3728cff.html" title="Last updated on Feb 27, 2024, 10:06 PM UTC (3728cff)">Diff</a>