### PR TITLE
Avoid non-normative uses of "may"

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2603,9 +2603,9 @@ enum EncodedAudioChunkType {
         to the {{EncodedAudioChunk}} internal slot in |value| with the same name
         as the named field.
 
-NOTE: <span class=allow-2119>Since {{EncodedAudioChunk}}s are immutable, User
-    Agents may choose to implement serialization using a reference counting
-    model similar to [[#audiodata-transfer-serialization]].</span>
+NOTE: Since {{EncodedAudioChunk}}s are immutable, User
+    Agents can choose to implement serialization using a reference counting
+    model similar to [[#audiodata-transfer-serialization]].
 
 EncodedVideoChunk Interface{#encodedvideochunk-interface}
 -----------------------------------------------------------
@@ -2711,9 +2711,9 @@ enum EncodedVideoChunkType {
         to the {{EncodedVideoChunk}} internal slot in |value| with the same name
         as the named field.
 
-NOTE: <span class=allow-2119>Since {{EncodedVideoChunk}}s are immutable, User
-    Agents may choose to implement serialization using a reference counting
-    model similar to [[#videoframe-transfer-serialization]].</span>
+NOTE: Since {{EncodedVideoChunk}}s are immutable, User
+    Agents can choose to implement serialization using a reference counting
+    model similar to [[#videoframe-transfer-serialization]].
 
 
 Raw Media Interfaces {#raw-media-interfaces}


### PR DESCRIPTION
Addressing: https://github.com/w3c/webcodecs/issues/768


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Djuffin/webcodecs/pull/771.html" title="Last updated on Feb 28, 2024, 9:37 PM UTC (73f325b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/771/724ad87...Djuffin:73f325b.html" title="Last updated on Feb 28, 2024, 9:37 PM UTC (73f325b)">Diff</a>