### PR TITLE
Add missing metadata to VideoFrameBufferInit

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3379,6 +3379,8 @@ dictionary VideoFrameBufferInit {
   VideoColorSpaceInit colorSpace;
 
   sequence<ArrayBuffer> transfer = [];
+
+  VideoFrameMetadata metadata;
 };
 
 dictionary VideoFrameMetadata {
@@ -3613,7 +3615,7 @@ dictionary VideoFrameMetadata {
         algorithm, with |colorSpace| and {{VideoFrame/[[format]]}}, to
         {{VideoFrame/[[color space]]}}.
     11. Assign the result of calling [=Copy VideoFrame metadata=]
-        with |init|'s {{VideoFrameInit/metadata}} to
+        with |init|'s {{VideoFrameBufferInit/metadata}} to
         |frame|.{{VideoFrame/[[metadata]]}}.
 22. Return |frame|.
 


### PR DESCRIPTION
Addressing https://github.com/w3c/webcodecs/issues/773


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Djuffin/webcodecs/pull/775.html" title="Last updated on Mar 5, 2024, 3:24 AM UTC (bb757da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/775/724ad87...Djuffin:bb757da.html" title="Last updated on Mar 5, 2024, 3:24 AM UTC (bb757da)">Diff</a>