### PR TITLE
Fix a typo in Compute Layout and Allocation Size algorithm

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4118,7 +4118,7 @@ A <dfn>computed plane layout</dfn> is a [=struct=] that consists of:
             multiplied by |sampleBytes|.
         9. Set |computedLayout|'s [=computed plane layout/sourceWidthBytes=] to
             the result of the integer division of
-            truncated |parsedRect|.{{DOMRectInit/width}} by |sampleHeight|,
+            truncated |parsedRect|.{{DOMRectInit/width}} by |sampleWidth|,
             multiplied by |sampleBytes|.
         10. If |layout| is not `undefined`:
             1. Let |planeLayout| be the {{PlaneLayout}} in |layout| at position


### PR DESCRIPTION
Addressing https://github.com/w3c/webcodecs/issues/774


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Djuffin/webcodecs/pull/776.html" title="Last updated on Mar 5, 2024, 3:25 AM UTC (970b34b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/776/724ad87...Djuffin:970b34b.html" title="Last updated on Mar 5, 2024, 3:25 AM UTC (970b34b)">Diff</a>