### PR TITLE
Add OpusEncoderConfig.[signal/application]

### DIFF
--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -226,7 +226,7 @@ enum OpusSignal {
 </pre>
 
 The {{OpusSignal}} describes the type of audio signal being encoded. See
-[secion 9.3.1.1](https://draft.ortc.org/#opus-codec-options*) of [[OBJECT-RTC]].
+[section 9.3.1.1](https://draft.ortc.org/#opus-codec-options*) of [[OBJECT-RTC]].
 
 <dl>
   <dt><dfn enum-value for=OpusSignal>auto</dfn></dt>
@@ -256,7 +256,7 @@ enum OpusApplication {
 </pre>
 
 The {{OpusApplication}} describes the intended application. See
-[secion 9.3.1.1](https://draft.ortc.org/#opus-codec-options*) of [[OBJECT-RTC]].
+[section 9.3.1.1](https://draft.ortc.org/#opus-codec-options*) of [[OBJECT-RTC]].
 
 <dl>
   <dt><dfn enum-value for=OpusApplication>voip</dfn></dt>

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -46,12 +46,6 @@ Markup Shorthands:css no, markdown yes, dfn yes
     "title": "RFC 7845: Ogg Encapsulation for the Opus Audio Codec",
     "publisher": "IETF",
     "date": "April 2016"
-  },
-  "OBJECT-RTC": {
-    "href": "https://w3c.github.io/ortc/",
-    "title": "Object RTC (ORTC) API for WebRTC",
-    "publisher": "W3C",
-    "date": "January 2021"
   }
 }
 </pre>
@@ -225,13 +219,12 @@ enum OpusSignal {
 </xmp>
 </pre>
 
-The {{OpusSignal}} describes the type of audio signal being encoded. See
-[section 9.3.1.1](https://draft.ortc.org/#opus-codec-options*) of [[OBJECT-RTC]].
+The {{OpusSignal}} indicates the default value for the type of signal being encoded.
 
 <dl>
   <dt><dfn enum-value for=OpusSignal>auto</dfn></dt>
   <dd>
-    The audio signal is not known to be of a particular type.
+    The audio signal is not specified to be of a particular type.
   </dd>
   <dt><dfn enum-value for=OpusSignal>music</dfn></dt>
   <dd>
@@ -255,8 +248,8 @@ enum OpusApplication {
 </xmp>
 </pre>
 
-The {{OpusApplication}} describes the intended application. See
-[section 9.3.1.1](https://draft.ortc.org/#opus-codec-options*) of [[OBJECT-RTC]].
+The {{OpusApplication}} indicates the default value for the encoder's intended
+application.
 
 <dl>
   <dt><dfn enum-value for=OpusApplication>voip</dfn></dt>

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -46,6 +46,12 @@ Markup Shorthands:css no, markdown yes, dfn yes
     "title": "RFC 7845: Ogg Encapsulation for the Opus Audio Codec",
     "publisher": "IETF",
     "date": "April 2016"
+  },
+  "OBJECT-RTC": {
+    "href": "https://w3c.github.io/ortc/",
+    "title": "Object RTC (ORTC) API for WebRTC",
+    "publisher": "W3C",
+    "date": "January 2021"
   }
 }
 </pre>
@@ -115,6 +121,8 @@ OpusEncoderConfig {#opus-encoder-config}
 <xmp>
 dictionary OpusEncoderConfig {
   OpusBitstreamFormat format = "opus";
+  OpusSignal signal = "auto";
+  OpusApplication application = "audio";
   [EnforceRange] unsigned long long frameDuration = 20000;
   [EnforceRange] unsigned long complexity;
   [EnforceRange] unsigned long packetlossperc = 0;
@@ -138,6 +146,14 @@ To check if an {{OpusEncoderConfig}} is valid, run these steps:
   <dd>
     Configures the format of output {{EncodedAudioChunk}}s. See
     {{OpusBitstreamFormat}}.
+  </dd>
+  <dt><dfn dict-member for=OpusEncoderConfig>signal</dfn></dt>
+  <dd>
+    Specificies the type of audio signal being encoded. See {{OpusSignal}}.
+  </dd>
+  <dt><dfn dict-member for=OpusEncoderConfig>application</dfn></dt>
+  <dd>
+    Specificies the encoder's intended application. See {{OpusApplication}}.
   </dd>
   <dt><dfn dict-member for=OpusEncoderConfig>frameDuration</dfn></dt>
   <dd>
@@ -194,6 +210,67 @@ encoded audio stream.
   <dd>
     The metadata of the encoded audio stream are provided at configuration via
     {{AudioDecoderConfig/description|AudioDecoderConfig.description}}.
+  </dd>
+</dl>
+
+OpusSignal {#opus-signal}
+------------------------------------------
+<pre class='idl'>
+<xmp>
+enum OpusSignal {
+  "auto",
+  "music",
+  "voice",
+};
+</xmp>
+</pre>
+
+The {{OpusSignal}} describes the type of audio signal being encoded. See
+[secion 9.3.1.1](https://draft.ortc.org/#opus-codec-options*) of [[OBJECT-RTC]].
+
+<dl>
+  <dt><dfn enum-value for=OpusSignal>auto</dfn></dt>
+  <dd>
+    The audio signal is not known to be of a particular type.
+  </dd>
+  <dt><dfn enum-value for=OpusSignal>music</dfn></dt>
+  <dd>
+    The audio signal is music.
+  </dd>
+  <dt><dfn enum-value for=OpusSignal>voice</dfn></dt>
+  <dd>
+    The audio signal is voice or speech.
+  </dd>
+</dl>
+
+OpusApplication {#opus-application}
+------------------------------------------
+<pre class='idl'>
+<xmp>
+enum OpusApplication {
+  "voip",
+  "audio",
+  "lowdelay",
+};
+</xmp>
+</pre>
+
+The {{OpusApplication}} describes the intended application. See
+[secion 9.3.1.1](https://draft.ortc.org/#opus-codec-options*) of [[OBJECT-RTC]].
+
+<dl>
+  <dt><dfn enum-value for=OpusApplication>voip</dfn></dt>
+  <dd>
+    Process signal for improved speech intelligibility.
+  </dd>
+  <dt><dfn enum-value for=OpusApplication>audio</dfn></dt>
+  <dd>
+    Favor faithfulness to the original input.
+  </dd>
+  <dt><dfn enum-value for=OpusApplication>lowdelay</dfn></dt>
+  <dd>
+    Configure the minimum possible coding delay by disabling certain modes of
+    operation.
   </dd>
 </dl>
 


### PR DESCRIPTION
Follow up work for #759.

`AudioEncoderConfig.contenHint` was not added, since only the Opus codec would benefit from it. Instead, we favored adding the individual codec configuration parameters directly to the Opus registry.

This PR adds `OpusEncoderConfig.signal` and `OpusEncoderConfig.application`.