### PR TITLE
sampleRate and numberOfChannels are required and have to be non-zero in a valid AudioEncoderConfig

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2051,8 +2051,8 @@ AudioEncoderConfig{#audio-encoder-config}
 <xmp class='idl'>
 dictionary AudioEncoderConfig {
   required DOMString codec;
-  [EnforceRange] unsigned long sampleRate;
-  [EnforceRange] unsigned long numberOfChannels;
+  [EnforceRange] required unsigned long sampleRate;
+  [EnforceRange] required unsigned long numberOfChannels;
   [EnforceRange] unsigned long long bitrate;
   BitrateMode bitrateMode = "variable";
 };
@@ -2069,7 +2069,9 @@ run these steps:
 2. If the {{AudioEncoderConfig}} has a codec-specific extension and the corresponding
     registration in the [[WEBCODECS-CODEC-REGISTRY]] defines steps to check whether
     the extension is a valid extension, return the result of running those steps.
-3. Return `true`.
+3. If {{AudioEncoderConfig/sampleRate}} or {{AudioEncoderConfig/numberOfChannels}} are
+     equal to zero, return `false`.
+4. Return `true`.
 
 <dl>
   <dt><dfn dict-member for=AudioEncoderConfig>codec</dfn></dt>


### PR DESCRIPTION
They are not required for decoding -- this depends on the codec.

This fixes #714.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/780.html" title="Last updated on Mar 15, 2024, 10:04 AM UTC (0446a14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/780/c97f298...0446a14.html" title="Last updated on Mar 15, 2024, 10:04 AM UTC (0446a14)">Diff</a>