### PR TITLE
Change type of EncodedVideoChunkInit.data to AllowSharedBufferSource

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2524,7 +2524,7 @@ dictionary EncodedAudioChunkInit {
   required EncodedAudioChunkType type;
   [EnforceRange] required long long timestamp;    // microseconds
   [EnforceRange] unsigned long long duration;     // microseconds
-  required BufferSource data;
+  required AllowSharedBufferSource data;
   sequence<ArrayBuffer> transfer = [];
 };
 


### PR DESCRIPTION
Addressing: https://github.com/w3c/webcodecs/issues/788


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/789.html" title="Last updated on May 17, 2024, 10:42 PM UTC (e24df65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/789/dcbf0ce...e24df65.html" title="Last updated on May 17, 2024, 10:42 PM UTC (e24df65)">Diff</a>