### PR TITLE
Clarify when ImageDecoder ready, completed promises are rejected.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -5469,7 +5469,8 @@ interface ImageDecoder {
     2. If {{ImageDecoder/[[encoded data]]}} does not contain enough data to
         determine the number of tracks:
         1. If {{ImageDecoder/complete}} is `true`, [=queue a task=] to run the
-            [=ImageDecoder/Close ImageDecoder=] algorithm.
+            [=ImageDecoder/Close ImageDecoder=] algorithm with a
+	    {{InvalidStateError}} {{DOMException}}.
         2. Abort these steps.
     3. If the number of tracks is found to be `0`, [=queue a task=] to run the
         [=ImageDecoder/Close ImageDecoder=] algorithm and abort these steps.
@@ -5733,10 +5734,14 @@ interface ImageDecoder {
     1. Assign `true` to {{ImageDecoder/[[closed]]}}.
     2. Clear {{ImageDecoder/[[codec implementation]]}} and release associated
         [=system resources=].
-    3. Remove all entries from {{ImageDecoder/[[ImageTrackList]]}}.
-    4. Assign `-1` to {{ImageDecoder/[[ImageTrackList]]}}'s
-        {{ImageTrackList/[[selected index]]}}.
-
+    3. If {{ImageDecoder/[[ImageTrackList]]}} is empty, reject
+	{{ImageTrackList/[[ready promise]]}} with |exception|. Otherwise
+	perform these steps,
+    	1. Remove all entries from {{ImageDecoder/[[ImageTrackList]]}}.
+    	2. Assign `-1` to {{ImageDecoder/[[ImageTrackList]]}}'s
+           {{ImageTrackList/[[selected index]]}}.
+    4. If {{ImageDecoder/[[complete]]}} is false resolve
+	{{ImageDecoder/[[completed promise]]}} with |exception|.
 
 ImageDecoderInit Interface {#imagedecoderinit-interface}
 --------------------------------------------------------
@@ -5890,9 +5895,10 @@ interface ImageTrackList {
 : <dfn attribute for=ImageTrackList>[[track list]]</dfn>
 :: The list of {{ImageTrack}}s describe by this {{ImageTrackList}}.
 
-: <dfn attribute for=ImageTrackList>\[[selected index]]</dfn>
+: <dfn attribute for=ImageTrackList>[[selected index]]</dfn>
 :: The index of the selected track in {{ImageTrackList/[[track list]]}}. A
-    value of `-1` indicates that no track is selected.
+    value of `-1` indicates that no track is selected. The initial value
+    is `-1`.
 
 ### Attributes ### {#imagetracklist-attributes}
 : <dfn attribute for=ImageTrackList>ready</dfn>

--- a/index.src.html
+++ b/index.src.html
@@ -5740,8 +5740,8 @@ interface ImageDecoder {
         1. Remove all entries from {{ImageDecoder/[[ImageTrackList]]}}.
         2. Assign `-1` to {{ImageDecoder/[[ImageTrackList]]}}'s
             {{ImageTrackList/[[selected index]]}}.
-   4. If {{ImageDecoder/[[complete]]}} is false resolve
-        {{ImageDecoder/[[completed promise]]}} with |exception|.
+    4. If {{ImageDecoder/[[complete]]}} is false resolve
+	{{ImageDecoder/[[completed promise]]}} with |exception|.
 
 ImageDecoderInit Interface {#imagedecoderinit-interface}
 --------------------------------------------------------

--- a/index.src.html
+++ b/index.src.html
@@ -5741,7 +5741,7 @@ interface ImageDecoder {
         2. Assign `-1` to {{ImageDecoder/[[ImageTrackList]]}}'s
             {{ImageTrackList/[[selected index]]}}.
     4. If {{ImageDecoder/[[complete]]}} is false resolve
-	{{ImageDecoder/[[completed promise]]}} with |exception|.
+        {{ImageDecoder/[[completed promise]]}} with |exception|.
 
 ImageDecoderInit Interface {#imagedecoderinit-interface}
 --------------------------------------------------------

--- a/index.src.html
+++ b/index.src.html
@@ -5470,7 +5470,7 @@ interface ImageDecoder {
         determine the number of tracks:
         1. If {{ImageDecoder/complete}} is `true`, [=queue a task=] to run the
             [=ImageDecoder/Close ImageDecoder=] algorithm with a
-	    {{InvalidStateError}} {{DOMException}}.
+            {{InvalidStateError}} {{DOMException}}.
         2. Abort these steps.
     3. If the number of tracks is found to be `0`, [=queue a task=] to run the
         [=ImageDecoder/Close ImageDecoder=] algorithm and abort these steps.
@@ -5735,13 +5735,13 @@ interface ImageDecoder {
     2. Clear {{ImageDecoder/[[codec implementation]]}} and release associated
         [=system resources=].
     3. If {{ImageDecoder/[[ImageTrackList]]}} is empty, reject
-	{{ImageTrackList/[[ready promise]]}} with |exception|. Otherwise
-	perform these steps,
-    	1. Remove all entries from {{ImageDecoder/[[ImageTrackList]]}}.
-    	2. Assign `-1` to {{ImageDecoder/[[ImageTrackList]]}}'s
-           {{ImageTrackList/[[selected index]]}}.
-    4. If {{ImageDecoder/[[complete]]}} is false resolve
-	{{ImageDecoder/[[completed promise]]}} with |exception|.
+        {{ImageTrackList/[[ready promise]]}} with |exception|. Otherwise
+        perform these steps,
+        1. Remove all entries from {{ImageDecoder/[[ImageTrackList]]}}.
+        2. Assign `-1` to {{ImageDecoder/[[ImageTrackList]]}}'s
+            {{ImageTrackList/[[selected index]]}}.
+   4. If {{ImageDecoder/[[complete]]}} is false resolve
+        {{ImageDecoder/[[completed promise]]}} with |exception|.
 
 ImageDecoderInit Interface {#imagedecoderinit-interface}
 --------------------------------------------------------
@@ -5895,7 +5895,7 @@ interface ImageTrackList {
 : <dfn attribute for=ImageTrackList>[[track list]]</dfn>
 :: The list of {{ImageTrack}}s describe by this {{ImageTrackList}}.
 
-: <dfn attribute for=ImageTrackList>[[selected index]]</dfn>
+: <dfn attribute for=ImageTrackList>\[[selected index]]</dfn>
 :: The index of the selected track in {{ImageTrackList/[[track list]]}}. A
     value of `-1` indicates that no track is selected. The initial value
     is `-1`.


### PR DESCRIPTION
Updates the text to clarify when these promises should be  rejected based on what layout tests and sole implementation  currently does.

Fixes #793


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/795.html" title="Last updated on Jun 5, 2024, 8:31 PM UTC (2fc8ad1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/795/485f58e...2fc8ad1.html" title="Last updated on Jun 5, 2024, 8:31 PM UTC (2fc8ad1)">Diff</a>