### PR TITLE
Add SecureContext to ImageTrack, ImageTrackList

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -5872,7 +5872,7 @@ ImageTrackList Interface {#imagetracklist-interface}
 ----------------------------------------------------
 <pre class='idl'>
 <xmp>
-[Exposed=(Window,DedicatedWorker)]
+[Exposed=(Window,DedicatedWorker), SecureContext]
 interface ImageTrackList {
   getter ImageTrack (unsigned long index);
 
@@ -5923,7 +5923,7 @@ ImageTrack Interface {#imagetrack-interface}
 --------------------------------------------
 <pre class='idl'>
 <xmp>
-[Exposed=(Window,DedicatedWorker)]
+[Exposed=(Window,DedicatedWorker), SecureContext]
 interface ImageTrack {
   readonly attribute boolean animated;
   readonly attribute unsigned long frameCount;


### PR DESCRIPTION
These aren't constructible by the page, so they should have the same SecureContext annotation that ImageDecoder does.