### PR TITLE
Mark ImageDecoderInit.data as AllowSharedBufferSource.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -5747,7 +5747,7 @@ ImageDecoderInit Interface {#imagedecoderinit-interface}
 --------------------------------------------------------
 <pre class='idl'>
 <xmp>
-typedef (BufferSource or ReadableStream) ImageBufferSource;
+typedef (AllowSharedBufferSource or ReadableStream) ImageBufferSource;
 dictionary ImageDecoderInit {
   required DOMString type;
   required ImageBufferSource data;


### PR DESCRIPTION
This is what Chromium implements, but we forgot to update the spec when other data fields were changed to allow shared buffers.

Fixes #799


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/802.html" title="Last updated on Jun 10, 2024, 5:00 PM UTC (90ab77c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/802/9eaaad4...90ab77c.html" title="Last updated on Jun 10, 2024, 5:00 PM UTC (90ab77c)">Diff</a>