### PR TITLE
VideoFrame.timestamp and EncodedVideoChunk.timestamp

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3695,8 +3695,8 @@ dictionary VideoFrameMetadata {
 : <dfn attribute for=VideoFrame>timestamp</dfn>
 :: The presentation timestamp, given in microseconds. For decode,
     timestamp is copied from the {{EncodedVideoChunk}} corresponding
-    to this VideoFrame. For encode, timestamp is copied to the
-    {{EncodedVideoChunk}}s corresponding to this VideoFrame. 
+    to this {{VideoFrame}}. For encode, timestamp is copied to the
+    {{EncodedVideoChunk}}s corresponding to this {{VideoFrame}}. 
 
     The {{VideoFrame/timestamp}} getter steps are to return
     {{VideoFrame/[[timestamp]]}}.

--- a/index.src.html
+++ b/index.src.html
@@ -3693,8 +3693,10 @@ dictionary VideoFrameMetadata {
     {{VideoFrame/[[display height]]}}.
 
 : <dfn attribute for=VideoFrame>timestamp</dfn>
-:: The presentation timestamp, given in microseconds. The timestamp is copied
-    from the {{EncodedVideoChunk}} corresponding to this VideoFrame.
+:: The presentation timestamp, given in microseconds. For decode,
+    timestamp is copied from the {{EncodedVideoChunk}} corresponding
+    to this VideoFrame. For encode, timestamp is copied to the
+    {{EncodedVideoChunk}}s corresponding to this VideoFrame. 
 
     The {{VideoFrame/timestamp}} getter steps are to return
     {{VideoFrame/[[timestamp]]}}.


### PR DESCRIPTION
Fix for https://github.com/w3c/webcodecs/issues/809


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/812.html" title="Last updated on Jul 3, 2024, 1:12 PM UTC (c3de570)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/812/7073bbf...c3de570.html" title="Last updated on Jul 3, 2024, 1:12 PM UTC (c3de570)">Diff</a>