### PR TITLE
Add captureTime, receiveTime and rtpTimestamp to VideoFrameMetadata

### DIFF
--- a/video_frame_metadata_registry.src.html
+++ b/video_frame_metadata_registry.src.html
@@ -61,6 +61,18 @@ VideoFrameMetadata members {#videoframemetadata-members}
     <td>segments</td>
     <td>[Human face segmentation](https://w3c.github.io/mediacapture-extensions/#human-face-segmentation)</td>
   </tr>
+  <tr>
+    <td>captureTime</td>
+    <td>[Capture time](https://wicg.github.io/video-rvfc/#dom-videoframecallbackmetadata-capturetime)</td>
+  </tr>
+  <tr>
+    <td>receiveTime</td>
+    <td>[Receive time](https://wicg.github.io/video-rvfc/#dom-videoframecallbackmetadata-receivetime)</td>
+  </tr>
+  <tr>
+    <td>rtpTimestamp</td>
+    <td>[RTP timestamp](https://wicg.github.io/video-rvfc/#dom-videoframecallbackmetadata-rtptimestamp)</td>
+  </tr>
 </table>
 
 

--- a/video_frame_metadata_registry.src.html
+++ b/video_frame_metadata_registry.src.html
@@ -63,15 +63,15 @@ VideoFrameMetadata members {#videoframemetadata-members}
   </tr>
   <tr>
     <td>captureTime</td>
-    <td>[Capture time](https://wicg.github.io/video-rvfc/#dom-videoframecallbackmetadata-capturetime)</td>
+    <td>[Capture time](https://w3c.github.io/mediacapture-extensions/#dfn-capture-timestamp)</td>
   </tr>
   <tr>
     <td>receiveTime</td>
-    <td>[Receive time](https://wicg.github.io/video-rvfc/#dom-videoframecallbackmetadata-receivetime)</td>
+    <td>[Receive time](https://w3c.github.io/mediacapture-extensions/#dfn-receive-timestamp)</td>
   </tr>
   <tr>
     <td>rtpTimestamp</td>
-    <td>[RTP timestamp](https://wicg.github.io/video-rvfc/#dom-videoframecallbackmetadata-rtptimestamp)</td>
+    <td>[RTP timestamp](https://w3c.github.io/mediacapture-extensions/#dfn-rtp-timestamp)</td>
   </tr>
 </table>
 

--- a/video_frame_metadata_registry.src.html
+++ b/video_frame_metadata_registry.src.html
@@ -63,15 +63,15 @@ VideoFrameMetadata members {#videoframemetadata-members}
   </tr>
   <tr>
     <td>captureTime</td>
-    <td>[Capture time](https://w3c.github.io/mediacapture-extensions/#dfn-capture-timestamp)</td>
+    <td>[Capture time](https://w3c.github.io/mediacapture-extensions/#dom-videoframemetadata-capturetime)</td>
   </tr>
   <tr>
     <td>receiveTime</td>
-    <td>[Receive time](https://w3c.github.io/mediacapture-extensions/#dfn-receive-timestamp)</td>
+    <td>[Receive time](https://w3c.github.io/mediacapture-extensions/#dom-videoframemetadata-receivetime)</td>
   </tr>
   <tr>
     <td>rtpTimestamp</td>
-    <td>[RTP timestamp](https://w3c.github.io/mediacapture-extensions/#dfn-rtp-timestamp)</td>
+    <td>[RTP timestamp](https://w3c.github.io/mediacapture-extensions/#dom-videoframemetadata-rtptimestamp)</td>
   </tr>
 </table>
 


### PR DESCRIPTION
These fields are useful for WebRTC-based applications.
See issue #601 