### PR TITLE
Fix audio/video mix-up

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1305,8 +1305,8 @@ Algorithms {#audioencoder-algorithms}
 EncodedAudioChunkMetadata {#encoded-audio-chunk-metadata}
 ---------------------------------------------------------
 The following metadata dictionary is emitted by the
-{{EncodedVideoChunkOutputCallback}} alongside an associated
-{{EncodedVideoChunk}}.
+{{EncodedAudioChunkOutputCallback}} alongside an associated
+{{EncodedAudioChunk}}.
 
 <xmp class='idl'>
 dictionary EncodedAudioChunkMetadata {


### PR DESCRIPTION
This PR replaces `EncodedVideoChunk` with `EncodedAudioChunk` in https://w3c.github.io/webcodecs/#encoded-audio-chunk-metadata.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chrisguttandin/webcodecs/pull/818.html" title="Last updated on Jul 10, 2024, 7:32 PM UTC (bb04436)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/818/39c85f5...chrisguttandin:bb04436.html" title="Last updated on Jul 10, 2024, 7:32 PM UTC (bb04436)">Diff</a>