### PR TITLE
Remove duplicate codec string

### DIFF
--- a/mp3_codec_registration.src.html
+++ b/mp3_codec_registration.src.html
@@ -52,7 +52,6 @@ This codec has multiple equivalent codec strings:
 - `"mp3"`
 - `"mp4a.69"`
 - `"mp4a.6B"`
-- `"mp4a.69"`
 
 
 EncodedAudioChunk data {#encodedaudiochunk-data}


### PR DESCRIPTION
This PR removes a duplicate codec string from the MP3 Registration. For some reason `mp4a.69` is mentioned twice.

https://w3c.github.io/webcodecs/mp3_codec_registration.html#fully-qualified-codec-strings

I'm not entirely sure though if that duplication was intentional because it was already part of the issue that motivated this change: https://github.com/w3c/webcodecs/issues/333.