### PR TITLE
Allow newly created codecs to be reclaimed if the system is out of resources

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -3696,7 +3696,7 @@ dictionary VideoFrameMetadata {
 :: The presentation timestamp, given in microseconds. For decode,
     timestamp is copied from the {{EncodedVideoChunk}} corresponding
     to this {{VideoFrame}}. For encode, timestamp is copied to the
-    {{EncodedVideoChunk}}s corresponding to this {{VideoFrame}}. 
+    {{EncodedVideoChunk}}s corresponding to this {{VideoFrame}}.
 
     The {{VideoFrame/timestamp}} getter steps are to return
     {{VideoFrame/[[timestamp]]}}.
@@ -6032,14 +6032,10 @@ The rules governing when a codec may be reclaimed depend on whether the codec is
 an [=active=] or [=inactive=] codec and/or a [=background=] codec.
 
 An <dfn lt="active codec|active">active codec</dfn> is a codec that has
-received a call to `encode()`, `decode()`, `configure()`, `flush()` or `reset()`
-in the past `10 seconds`, or has called its `output()` callback in the past `10
-seconds`. Addionally, {{VideoEncoder}}s are considered [=active=] if they are
-making progress in encoding queued {{VideoFrame}}s.
+made progress on the [=[[codec work queue]]=] in the past `10 seconds`.
 
-NOTE: Encoding large {{VideoFrame}}s can take more than `10s` per frame. The
-special case for {{VideoEncoder}}s ensures that they are not reclaimed if more
-than `10 seconds` elapses between each `output()` callback.
+NOTE: A reliable sign of the working queue's progress is a call to `output()`
+    callback.
 
 An <dfn lt="inactive codec|inactive">inactive codec</dfn> is any codec that does
 not meet the definition of an [=active codec=].


### PR DESCRIPTION
This PR addresses https://github.com/w3c/webcodecs/issues/669


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Djuffin/webcodecs/pull/836.html" title="Last updated on Oct 2, 2024, 2:27 AM UTC (b5e1d38)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/836/6fd01eb...Djuffin:b5e1d38.html" title="Last updated on Oct 2, 2024, 2:27 AM UTC (b5e1d38)">Diff</a>