### PR TITLE
Specify format of buffer we're copying into

### DIFF
--- a/samples/lib/audio_renderer.js
+++ b/samples/lib/audio_renderer.js
@@ -176,7 +176,7 @@ export class AudioRenderer {
     debugLog(`bufferAudioData() ts:${data.timestamp} durationSec:${data.duration / 1000000}`);
     // Write to temporary planar arrays, and interleave into the ring buffer.
     for (var i = 0; i < this.channelCount; i++) {
-      data.copyTo(this.interleavingBuffers[i], { planeIndex: i });
+      data.copyTo(this.interleavingBuffers[i], { planeIndex: i, format: "f32-planar" });
     }
     // Write the data to the ring buffer. Because it wraps around, there is
     // potentially two copyTo to do.


### PR DESCRIPTION
Per spec https://w3c.github.io/webcodecs/#dom-audiodatacopytooptions-format if the format is not specified, we are to use the same format as the source. Which could be interleaved as the format for decoding isn't specified.

Calling copyTo with a planeIndex of 0 with an interleaved buffer will attempt to copy all planes.

So we just set the destination format to be f32-planar.

This allows playback to start on browsers that aren't Blink based (Firefox, Safari)