### PR TITLE
A control message should always return either "processed" or "not pro…

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -484,6 +484,7 @@ Methods {#audiodecoder-methods}
             2. Remove |promise| from
                 {{AudioDecoder/[[pending flush promises]]}}.
             3. Resolve |promise|.
+    2. Return `"processed"`.
   </dd>
 
   <dt><dfn method for=AudioDecoder>reset()</dfn></dt>
@@ -829,6 +830,7 @@ Methods {#videodecoder-methods}
             2. Remove |promise| from
                 {{VideoDecoder/[[pending flush promises]]}}.
             3. Resolve |promise|.
+    2. Return `"processed"`.
   </dd>
 
   <dt><dfn method for=VideoDecoder>reset()</dfn></dt>
@@ -1167,6 +1169,7 @@ Methods {#audioencoder-methods}
             2. Remove |promise| from
                 {{AudioEncoder/[[pending flush promises]]}}.
             3. Resolve |promise|.
+    2. Return `"processed"`.
   </dd>
 
   <dt><dfn method for=AudioEncoder>reset()</dfn></dt>
@@ -1542,6 +1545,7 @@ Methods {#videoencoder-methods}
             2. Remove |promise| from
                 {{VideoEncoder/[[pending flush promises]]}}.
             3. Resolve |promise|.
+    2. Return `"processed"`.
   </dd>
 
   <dt><dfn method for=VideoEncoder>reset()</dfn></dt>


### PR DESCRIPTION
…cessed".

flush() control message didn't return anything. We return "processed".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyavenard/webcodecs/pull/862.html" title="Last updated on Dec 12, 2024, 12:00 AM UTC (dfea2b3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/862/41636a6...jyavenard:dfea2b3.html" title="Last updated on Dec 12, 2024, 12:00 AM UTC (dfea2b3)">Diff</a>