### PR TITLE
Fix references to WebAudio

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -33,6 +33,8 @@ spec:html; type:attribute; text:hidden
 spec:html; type:enum-value; text:srgb
 spec:infra; type:dfn; text:list
 spec:infra; type:dfn; text:enqueue
+spec:webaudio-1.1; type:interface; text:AudioWorklet
+spec:webaudio-1.1; type:interface; text:AudioBuffer
 </pre>
 
 <pre class='anchors'>


### PR DESCRIPTION
bikeshed was unhappy with the spec.

```
 $ bikeshed --die-on=warning spec "index.src.html" "index.src.html.built.html" --md-status="WD" --md-date="2024-12-12" --md-Prepare-For-TR="yes" --md-previous-version="https://www.w3.org/TR/2024/WD-webcodecs-20241008/"
      LINK ERROR: Multiple possible 'AudioBuffer' idl refs.
      Arbitrarily chose https://www.w3.org/TR/webaudio-1.0/#audiobuffer
      To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
      spec:webaudio-1.0; type:interface; text:AudioBuffer
      spec:webaudio-1.1; type:interface; text:AudioBuffer
      {{AudioBuffer}}
      LINK ERROR: Multiple possible 'AudioWorklet' idl refs.
      Arbitrarily chose https://www.w3.org/TR/webaudio-1.0/#audioworklet
      To auto-select one of the following refs, insert one of these lines into a <pre class=link-defaults> block:
      spec:webaudio-1.0; type:interface; text:AudioWorklet
      spec:webaudio-1.1; type:interface; text:AudioWorklet
      {{AudioWorklet}}
       ✘  Did not generate, due to errors exceeding the allowed error level.
```