### PR TITLE
Handle case where AudioContext.outputLatency isn't implemented.

### DIFF
--- a/samples/lib/web_audio_controller.js
+++ b/samples/lib/web_audio_controller.js
@@ -77,8 +77,8 @@ export class WebAudioController {
     // hardware buffering, etc. This starts out negative, because it takes some
     // time to buffer, and crosses zero as the first audio sample is produced
     // by the audio output device.
-    let totalOutputLatency =
-        this.audioContext.outputLatency + this.audioContext.baseLatency;
+    let outputLatency = this.audioContext.outputLatency ? this.audioContext.outputLatency : 0;
+    let totalOutputLatency = outputLatency + this.audioContext.baseLatency;
 
     return Math.max(this.audioContext.currentTime - totalOutputLatency, 0.0);
   }


### PR DESCRIPTION
Not all User Agents implement AudioContext.outputLatency (such as Safari). On those, totalOutputLatency would always be NaN, resulting in no video frames ever displayed.