### PR TITLE
GitHub actions: replace ubuntu-20.04 with ubuntu-latest

### DIFF
--- a/.github/workflows/deploy-images.yml
+++ b/.github/workflows/deploy-images.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       # See doc at https://github.com/actions/checkout#checkout-v2

--- a/.github/workflows/deploy-samples.yml
+++ b/.github/workflows/deploy-samples.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       # See doc at https://github.com/actions/checkout#checkout-v2


### PR DESCRIPTION
[GitHub will no longer support the Ubuntu 20.04 runner image starting from April 1, 2025](https://github.com/actions/runner-images/issues/11101). That PR updates the actions to use ubuntu-latest instead