### PR TITLE
Add backgroundSegmentationMask to VideoFrameMetadata registry

### DIFF
--- a/video_frame_metadata_registry.src.html
+++ b/video_frame_metadata_registry.src.html
@@ -77,6 +77,10 @@ VideoFrameMetadata members {#videoframemetadata-members}
     <td>backgroundBlur</td>
     <td>[Background blur effect status](https://w3c.github.io/mediacapture-extensions/#background-blur-effect-status)</td>
   </tr>
+  <tr>
+    <td>backgroundSegmentationMask</td>
+    <td>[Background segmentation mask](https://w3c.github.io/mediacapture-extensions/#background-segmentation-mask)</td>
+  </tr>
 </table>
 
 


### PR DESCRIPTION
Background segmentation mask is useful for Media Capture as discussed in https://github.com/w3c/mediacapture-extensions/pull/142.