### PR TITLE
Make AudioDecoderConfig.description AllowShared

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1940,7 +1940,7 @@ dictionary AudioDecoderConfig {
   required DOMString codec;
   [EnforceRange] required unsigned long sampleRate;
   [EnforceRange] required unsigned long numberOfChannels;
-  BufferSource description;
+  AllowSharedBufferSource description;
 };
 </xmp>
 


### PR DESCRIPTION
Mirroring https://github.com/w3c/webcodecs/pull/582.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/888.html" title="Last updated on Apr 17, 2025, 12:46 PM UTC (c5257e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/888/dc3cf30...c5257e2.html" title="Last updated on Apr 17, 2025, 12:46 PM UTC (c5257e2)">Diff</a>