### PR TITLE
Proper links for all references of codec strings

### DIFF
--- a/aac_codec_registration.src.html
+++ b/aac_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for AAC, the (1) fully qualified codec strings, (2) the
+    It describes, for AAC, the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]], (2) the
     codec-specific {{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}}
     bytes, (3) the {{AudioDecoderConfig/description|AudioDecoderConfig.description}}
     bytes, (4) the values of {{EncodedAudioChunk}} {{EncodedAudioChunk/[[type]]}},
@@ -47,7 +47,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-This codec has multiple possible codec strings:
+This codec has multiple possible [[WEBCODECS#config-codec-string|codec strings]]:
 
 - `"mp4a.40.2"` — MPEG-4 AAC LC
 - `"mp4a.40.02"` — MPEG-4 AAC LC, leading 0 for Aud-OTI compatibility

--- a/alaw_codec_registration.src.html
+++ b/alaw_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for A-law encoded PCM, the (1) fully qualified codec strings,
+    It describes, for A-law encoded PCM, the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]],
     (2) the codec-specific {{EncodedAudioChunk}}
     {{EncodedAudioChunk/[[internal data]]}} bytes, (3) the
     {{AudioDecoderConfig/description|AudioDecoderConfig.description}},
@@ -47,7 +47,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-The codec string is `"alaw"`.
+The [[WEBCODECS#config-codec-string|codec string]] is `"alaw"`.
 
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================

--- a/av1_codec_registration.src.html
+++ b/av1_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for AV1, the (1) fully qualified codec strings,
+    It describes, for AV1, the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]],
     (2) the codec-specific {{EncodedVideoChunk}}
     {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the codec-specific
     extensions to {{VideoEncoderConfig}}, (4) the
@@ -53,7 +53,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-The codec string begins with the prefix `"av01."`, followed by a variable length
+The [[WEBCODECS#config-codec-string|codec string]] begins with the prefix `"av01."`, followed by a variable length
 suffix as described in Section 5 of [[AV1-ISOBMFF]].
 
 EncodedVideoChunk data {#encodedvideochunk-data}

--- a/avc_codec_registration.src.html
+++ b/avc_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for AVC (H.264), the (1) fully qualified codec strings,
+    It describes, for AVC (H.264), the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]],
     (2) the codec-specific {{EncodedVideoChunk}}
     {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the
     {{VideoDecoderConfig/description|VideoDecoderConfig.description}} bytes,
@@ -55,7 +55,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-The codec string begins with the prefix "avc1." or "avc3.", with a suffix of 6
+The [[WEBCODECS#config-codec-string|codec string]] begins with the prefix "avc1." or "avc3.", with a suffix of 6
 characters as described respectively in Section 3.4 of [[rfc6381]] and Section
 5.4.1 of [[iso14496-15]].
 

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -39,16 +39,16 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Organization {#organization}
 ============================
 
-This registry maintains a mapping between codec strings and registration
+This registry maintains a mapping between <a>codec strings</a> and registration
 specifications as described below.
 
 Registration Entry Requirements {#registration-entry-requirements}
 ==================================================================
 
-1. Each entry must include a unique codec string, a common name string, and a
+1. Each entry must include a unique <a>codec string</a>, a common name string, and a
     link to the codec's specification.
-2. The codec string must be crafted as follows:
-    1. If the codec string contains a fixed prefix with variable suffix values,
+2. The <a>codec string</a> must be crafted as follows:
+    1. If the <a>codec string</a> contains a fixed prefix with variable suffix values,
         the suffix must be represented by an asterisk and the registration's
         public specification must describe how to fully qualify the variable
         portion of the string.
@@ -79,7 +79,7 @@ Registration Entry Requirements {#registration-entry-requirements}
     The registry editors will review and merge the pull request.
 6. Existing entries cannot be deleted or deprecated. They may be changed after
     being published through the same process as candidate entries. Possible
-    changes include expansion of the codec string to better qualify the codec,
+    changes include expansion of the <a>codec string</a> to better qualify the codec,
     adjustments to the codec name string, and modification of the link to the
     codec's specification.
 

--- a/flac_codec_registration.src.html
+++ b/flac_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for FLAC, the (1) fully qualified codec strings,
+    It describes, for FLAC, the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]],
     (2) the codec-specific {{EncodedAudioChunk}}
     {{EncodedAudioChunk/[[internal data]]}} bytes, (3) the
     {{AudioDecoderConfig/description|AudioDecoderConfig.description}} bytes,
@@ -47,7 +47,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-The codec string is `"flac"`.
+The [[WEBCODECS#config-codec-string|codec string]] is `"flac"`.
 
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================

--- a/hevc_codec_registration.src.html
+++ b/hevc_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for HEVC (H.265), the (1) fully qualified codec strings,
+    It describes, for HEVC (H.265), the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]],
     (2) the codec-specific {{EncodedVideoChunk}}
     {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the
     {{VideoDecoderConfig/description|VideoDecoderConfig.description}} bytes,
@@ -55,7 +55,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-The codec string begins with the prefix "hev1." or "hvc1.", with a suffix of
+The [[WEBCODECS#config-codec-string|codec string]] begins with the prefix "hev1." or "hvc1.", with a suffix of
 four dot-separated fields as described in Section E.3 of [[iso14496-15]].
 
 EncodedVideoChunk data {#encodedvideochunk-data}

--- a/index.src.html
+++ b/index.src.html
@@ -2013,8 +2013,7 @@ run these steps:
 
 <dl>
   <dt><dfn dict-member for=VideoDecoderConfig>codec</dfn></dt>
-  <dd>Contains a codec string describing the codec.</dd>
-
+  <dd>Contains a <a>codec string</a> describing the codec.</dd>
   <dt><dfn dict-member for=VideoDecoderConfig>description</dfn></dt>
   <dd>
     A sequence of codec specific bytes, commonly known as extradata.
@@ -2118,7 +2117,7 @@ run these steps:
 
 <dl>
   <dt><dfn dict-member for=AudioEncoderConfig>codec</dfn></dt>
-  <dd>Contains a codec string describing the codec.</dd>
+  <dd>Contains a <a>codec string</a> describing the codec.</dd>
 
   <dt><dfn dict-member for=AudioEncoderConfig>sampleRate</dfn></dt>
   <dd>The number of frame samples per second.</dd>

--- a/mp3_codec_registration.src.html
+++ b/mp3_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for MP3, the (1) fully qualified codec strings, (2)
+    It describes, for MP3, the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]], (2)
     the {{AudioDecoderConfig/description|AudioDecoderConfig.description}} bytes,
     (3) the codec-specific {{EncodedAudioChunk}}
     {{EncodedAudioChunk/[[internal data]]}} bytes, and (4)
@@ -48,7 +48,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-This codec has multiple equivalent codec strings:
+This codec has multiple equivalent [[WEBCODECS#config-codec-string|codec strings]]:
 
 - `"mp3"`
 - `"mp4a.69"`

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for Opus, the (1) fully qualified codec strings, (2) the
+    It describes, for Opus, the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]], (2) the
     codec-specific {{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}}
     bytes, (3) the {{AudioDecoderConfig/description|AudioDecoderConfig.description}}
     bytes, (4) the values of {{EncodedAudioChunk}} {{EncodedAudioChunk/[[type]]}},
@@ -54,7 +54,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-The codec string is `"opus"`.
+The [[WEBCODECS#config-codec-string|codec string]] is `"opus"`.
 
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================

--- a/pcm_codec_registration.src.html
+++ b/pcm_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for Linear PCM, the (1) fully qualified codec strings,
+    It describes, for Linear PCM, the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]],
     (2) the codec-specific {{EncodedAudioChunk}}
     {{EncodedAudioChunk/[[internal data]]}} bytes, (3) the
     {{AudioDecoderConfig/description|AudioDecoderConfig.description}}, and
@@ -47,8 +47,8 @@ spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-This codec's string begins with the prefix "pcm-", followed by a suffix that
-indicates the sample format. The complete list of strings and associated
+This [[WEBCODECS#config-codec-string|codec string]] begins with the prefix "pcm-", followed by a suffix that
+indicates the sample format. The complete list of [[WEBCODECS#config-codec-string|codec strings]] and associated
 formats is as follows.
 
 * pcm-u8, using format {{u8}}
@@ -72,7 +72,7 @@ between two successive values are linearly uniform.
 
 {{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}} is expected to be
 a sequence of bytes of arbitrary length, with a [=sample=] occuring every N
-bits, where N is defined by the codec string. For multichannel PCM, [=samples=]
+bits, where N is defined by the [[WEBCODECS#config-codec-string|codec string]]. For multichannel PCM, [=samples=]
 from different channels are [=interleaved=].
 
 

--- a/pcm_codec_registration.src.html
+++ b/pcm_codec_registration.src.html
@@ -41,6 +41,9 @@ Markup Shorthands:css no, markdown yes, dfn yes
 spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
     type: dfn
         text: interleaved; url: interleaved
+spec: WEBCODECS; urlPrefix: https://w3c.github.io/webcodecs/#
+    type: dfn
+        text: samples; url: sample
 </pre>
 
 
@@ -71,7 +74,7 @@ values are sampled at a regular interval, and where the quantization levels
 between two successive values are linearly uniform.
 
 {{EncodedAudioChunk}} {{EncodedAudioChunk/[[internal data]]}} is expected to be
-a sequence of bytes of arbitrary length, with a [=sample=] occuring every N
+a sequence of bytes of arbitrary length, with a [=sample=] occurring every N
 bits, where N is defined by the [[WEBCODECS#config-codec-string|codec string]]. For multichannel PCM, [=samples=]
 from different channels are [=interleaved=].
 

--- a/ulaw_codec_registration.src.html
+++ b/ulaw_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for u-law encoded PCM, the (1) fully qualified codec strings,
+    It describes, for u-law encoded PCM, the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]],
     (2) the codec-specific {{EncodedAudioChunk}}
     {{EncodedAudioChunk/[[internal data]]}} bytes, (3) the
     {{AudioDecoderConfig/description|AudioDecoderConfig.description}} bytes,
@@ -47,7 +47,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-The codec string is `"ulaw"`.
+The [[WEBCODECS#config-codec-string|codec string]] is `"ulaw"`.
 
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================

--- a/vorbis_codec_registration.src.html
+++ b/vorbis_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for Vorbis, the (1) fully qualified codec strings,
+    It describes, for Vorbis, the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]],
     (2) the codec-specific {{EncodedAudioChunk}}
     {{EncodedAudioChunk/[[internal data]]}} bytes, (3) the
     {{AudioDecoderConfig/description|AudioDecoderConfig.description}} bytes,
@@ -52,7 +52,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-The codec string is `"vorbis"`.
+The [[WEBCODECS#config-codec-string|codec string]] is `"vorbis"`.
 
 EncodedAudioChunk data {#encodedaudiochunk-data}
 ================================================

--- a/vp8_codec_registration.src.html
+++ b/vp8_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for VP8, the (1) fully qualified codec strings,
+    It describes, for VP8, the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]],
     (2) the codec-specific {{EncodedVideoChunk}}
     {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the
     {{VideoDecoderConfig/description|VideoDecoderConfig.description}} bytes,
@@ -46,7 +46,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-The codec string is `"vp8"`.
+The [[WEBCODECS#config-codec-string|codec string]] is `"vp8"`.
 
 EncodedVideoChunk data {#encodedvideochunk-data}
 ================================================

--- a/vp9_codec_registration.src.html
+++ b/vp9_codec_registration.src.html
@@ -13,7 +13,7 @@ Former Editor: Bernard Aboba, w3cid 65611, Microsoft Corporation https://www.mic
 Former Editor: Chris Cunningham, w3cid 114832, Google Inc. https://www.google.com/
 
 Abstract: This registration is entered into the [[webcodecs-codec-registry]].
-    It describes, for VP9, the (1) fully qualified codec strings,
+    It describes, for VP9, the (1) fully qualified [[WEBCODECS#config-codec-string|codec strings]],
     (2) the codec-specific {{EncodedVideoChunk}}
     {{EncodedVideoChunk/[[internal data]]}} bytes, (3) the
     {{VideoDecoderConfig/description|VideoDecoderConfig.description}} bytes,
@@ -52,7 +52,7 @@ Markup Shorthands:css no, markdown yes, dfn yes
 Fully qualified codec strings {#fully-qualified-codec-strings}
 ==============================================================
 
-The codec string begins with the prefix `"vp09."`, followed by a variable length
+The [[WEBCODECS#config-codec-string|codec string]] begins with the prefix `"vp09."`, followed by a variable length
 suffix as described in the "Codecs Parameter String" Section of [[VP9-ISOBMFF]].
 
 EncodedVideoChunk data {#encodedvideochunk-data}


### PR DESCRIPTION
This PR resolves: https://github.com/w3c/webcodecs/issues/872


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Djuffin/webcodecs/pull/895.html" title="Last updated on May 14, 2025, 8:20 PM UTC (9be9099)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/895/71fd338...Djuffin:9be9099.html" title="Last updated on May 14, 2025, 8:20 PM UTC (9be9099)">Diff</a>