### PR TITLE
Update QuotaExceededError usage

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -6184,7 +6184,7 @@ codecs are limited, and shared accross web pages or platform apps.
 To <dfn>reclaim a codec</dfn>, a User Agent <em class="rfc2119">MUST</em> run
 the appropriate close algorithm (amongst [=Close AudioDecoder=],
 [=Close AudioEncoder=], [=Close VideoDecoder=] and [=Close VideoEncoder=]) with
-a {{QuotaExceededError}} {{DOMException}}.
+a {{QuotaExceededError}}.
 
 The rules governing when a codec may be reclaimed depend on whether the codec is
 an [=active=] or [=inactive=] codec and/or a [=background=] codec.


### PR DESCRIPTION
QuotaExceededError is graduating from being a DOMException name into a new error class, in https://github.com/whatwg/webidl/pull/1465. Update creation sites to reflect this.

For now, the quota and requested properties are left at their default (null). Future work could include setting them in an informative fashion.