### PR TITLE
Update links and clarify participation requirement in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,12 @@
 # Contributing
 
 Contributions to this repository are intended to become part of Recommendation-track documents
-governed by the [W3C Patent Policy](http://www.w3.org/Consortium/Patent-Policy-20040205/) and
-[Software and Document License](http://www.w3.org/Consortium/Legal/copyright-software). To contribute, you must
-either participate in the relevant W3C Working Group or make a non-member patent licensing
- commitment.
+governed by the [W3C Patent Policy](https://www.w3.org/policies/patent-policy/) and
+[Software and Document License](https://www.w3.org/copyright/software-license/). To make substantive contributions to specifications, you must either participate
+in the relevant W3C Working Group or make a non-member patent licensing commitment.
 
 If you are not the sole contributor to a contribution (pull request), please identify all
-contributors in the pull request's body or in subsequent comments.
+contributors in the pull request comment.
 
  To add a contributor (other than yourself, that's automatic), mark them one per line as follows:
 


### PR DESCRIPTION
This aligns the file with the usual template file at: https://github.com/w3c/ash-nazg/blob/master/templates/WG-CONTRIBUTING-SW.md

Updates are:
1. The file gave the impression that the requirement to participate or make a non-member patent licensing commitment applied to all contributions, whereas it does not apply to non-substantive contributions in practice.
2. Links to the W3C Patent Policy and Software and Document License were adjusted.

Note: Same refresh will likely be needed in other Media WG repositories as I suspect I used the same outdated file everywhere.