### PR TITLE
AudioDecoderConfig.numberOfChannels and AudioDecoderConfig.sampleRate should be explicitly forbidden to be 0

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -1951,7 +1951,8 @@ To check if an {{AudioDecoderConfig}} is a <dfn export>valid AudioDecoderConfig<
     return `false`.
 2. If {{AudioDecoderConfig/description}} is [[=BufferSource/detached=]], return
      false.
-3. Return `true`.
+3. If {{AudioDecoderConfig/sampleRate}} or {{AudioDecoderConfig/numberOfChannels}} are equal to zero, return `false`.
+4. Return `true`.
 
 <dl>
   <dt><dfn dict-member for=AudioDecoderConfig>codec</dfn></dt>


### PR DESCRIPTION
This fixes #878.

This is what Firefox (and I think also Chrome) implements, and it's what is tested in WPT.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/908.html" title="Last updated on Nov 12, 2025, 1:39 AM UTC (b7f6869)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/908/fd0c13f...b7f6869.html" title="Last updated on Nov 12, 2025, 1:39 AM UTC (b7f6869)">Diff</a>