### PR TITLE
Fix missing tasks in parallel steps in WebCodecs

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -5583,8 +5583,10 @@ interface ImageDecoder {
     1. If |type| is not a [=valid image MIME type=], return a {{Promise}}
         rejected with {{TypeError}}.
     2. Let |p| be a new {{Promise}}.
-    3. In parallel, resolve |p| with the result of running the
-        [=Check Type Support=] algorithm with |type|.
+    3. Run the following steps [=in parallel=]:
+        1. Let |isSupported| be the result of running the
+            [=Check Type Support=] algorithm with |type|.
+        2. [=Queue a task=] to resolve |p| with |isSupported|.
     4. Return |p|.
 
 ### Algorithms ### {#imagedecoder-algorithms}


### PR DESCRIPTION
This fixes #877.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/909.html" title="Last updated on Nov 12, 2025, 1:44 AM UTC (24c129e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/909/fd0c13f...24c129e.html" title="Last updated on Nov 12, 2025, 1:44 AM UTC (24c129e)">Diff</a>