### PR TITLE
Fix typo (decodeQueuSize -> decodeQueueSize)

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -184,7 +184,7 @@ Definitions {#definitions}
     may be any value greater than 1, including infinity (no maximum). While
     saturated, additional calls to `decode()` or `encode()` will be buffered
     in the [=control message queue=], and will increment the respective
-    `decodeQueuSize` and `encodeQueueSize` attributes. The codec implementation
+    `decodeQueueSize` and `encodeQueueSize` attributes. The codec implementation
     will become unsaturated after making sufficient progress on the current
     workload.
 


### PR DESCRIPTION
In the "Codec Saturation" definition, there is a small typo.  This PR fixes it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mjwilson-google/webcodecs/pull/912.html" title="Last updated on Nov 19, 2025, 10:27 PM UTC (78be862)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/912/fd0c13f...mjwilson-google:78be862.html" title="Last updated on Nov 19, 2025, 10:27 PM UTC (78be862)">Diff</a>