### PR TITLE
fix typo (U an V -> U and V)

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -4595,7 +4595,7 @@ Integer values are unsigned unless otherwise specified.
     planes of Chroma, denoted Y, U and V, and present in this order. It is also
     often refered to as Planar YUV 4:2:0.
 
-    The U an V planes are [=sub-sampled=] horizontally and vertically by a
+    The U and V planes are [=sub-sampled=] horizontally and vertically by a
     [=factor=] of 2 compared to the Y plane.
 
     Each sample in this format is 8 bits.
@@ -4672,7 +4672,7 @@ Integer values are unsigned unless otherwise specified.
     present in this order. It is also often refered to as Planar YUV 4:2:0 with
     an alpha channel.
 
-    The U an V planes are [=sub-sampled=] horizontally and vertically by a
+    The U and V planes are [=sub-sampled=] horizontally and vertically by a
     [=factor=] of 2 compared to the Y and Alpha planes.
 
     Each sample in this format is 8 bits.
@@ -4756,7 +4756,7 @@ Integer values are unsigned unless otherwise specified.
     planes of Chroma, denoted Y, U and V, and present in this order. It is also
     often refered to as Planar YUV 4:2:2.
 
-    The U an V planes are [=sub-sampled=] horizontally by a [=factor=] of 2
+    The U and V planes are [=sub-sampled=] horizontally by a [=factor=] of 2
     compared to the Y plane, and not [=sub-sampled=] vertically.
 
     Each sample in this format is 8 bits.
@@ -5005,7 +5005,7 @@ Integer values are unsigned unless otherwise specified.
     another plane for the two Chroma components. The two planes are present in
     this order, and are refered to as respectively the Y plane and the UV plane.
 
-    The U an V components are [=sub-sampled=] horizontally and vertically by a
+    The U and V components are [=sub-sampled=] horizontally and vertically by a
     [=factor=] of 2 compared to the components in the Y planes.
 
     Each sample in this format is 8 bits.


### PR DESCRIPTION
In the **Video Pixel Format descriptions section**, there is a typo in the "U an V" word. This PR fixes it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tarunsinghofficial/webcodecs/pull/914.html" title="Last updated on Nov 21, 2025, 1:26 PM UTC (a36eb10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/914/66a81b2...tarunsinghofficial:a36eb10.html" title="Last updated on Nov 21, 2025, 1:26 PM UTC (a36eb10)">Diff</a>