### PR TITLE
Change AV1 and VP9 quantizer range from 0-63 to 0-255

### DIFF
--- a/av1_codec_registration.src.html
+++ b/av1_codec_registration.src.html
@@ -108,7 +108,7 @@ dictionary VideoEncoderEncodeOptionsForAv1 {
   <dt><dfn dict-member for=VideoEncoderEncodeOptionsForAv1>quantizer</dfn></dt>
   <dd>
     Sets per-frame quantizer value.
-    In [[AV1]] the quantizer threshold can be varied from 0 to 63
+    In [[AV1]] the quantizer index can be varied from 0 to 255
   </dd>
 </dl>
 

--- a/vp9_codec_registration.src.html
+++ b/vp9_codec_registration.src.html
@@ -106,7 +106,7 @@ dictionary VideoEncoderEncodeOptionsForVp9 {
   <dt><dfn dict-member for=VideoEncoderEncodeOptionsForVp9>quantizer</dfn></dt>
   <dd>
     Sets per-frame quantizer value.
-    In [[VP9]] the quantizer threshold can be varied from 0 to 63
+    In [[VP9]] the quantizer index can be varied from 0 to 255
   </dd>
 </dl>
 


### PR DESCRIPTION
This change fixes: https://github.com/w3c/webcodecs/issues/904