### PR TITLE
Mark `AudioDataInit/data` as AllowShared

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -2853,7 +2853,7 @@ dictionary AudioDataInit {
   [EnforceRange] required unsigned long numberOfFrames;
   [EnforceRange] required unsigned long numberOfChannels;
   [EnforceRange] required long long timestamp;  // microseconds
-  required BufferSource data;
+  required AllowSharedBufferSource data;
   sequence<ArrayBuffer> transfer = [];
 };
 </xmp>


### PR DESCRIPTION
Aligns with [Chromium](https://chromium.googlesource.com/chromium/src/+/main/third_party/blink/renderer/modules/webcodecs/audio_data_init.idl), and continues the trend of allowing shared data sources. The initialiser just copies the data, so doesn't look like any change to the spec text is needed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Renegade334/webcodecs/pull/916.html" title="Last updated on Nov 30, 2025, 4:04 PM UTC (dfdc588)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/916/087c83c...Renegade334:dfdc588.html" title="Last updated on Nov 30, 2025, 4:04 PM UTC (dfdc588)">Diff</a>