### PR TITLE
Fix Bikeshed build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,11 @@ else
 endif
 else
 	@ echo "Building $@ remotely"
-	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	@ (HTTP_STATUS=$$(curl https://www.w3.org/publications/spec-generator/ \
 	                       --output $@ \
 	                       --write-out "%{http_code}" \
 	                       --header "Accept: text/plain, text/html" \
+	                       -F type=bikeshed-spec \
 	                       -F die-on=warning \
 	                       -F file=@$<) && \
 	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \

--- a/index.src.html
+++ b/index.src.html
@@ -6261,6 +6261,7 @@ An additional concern is exposing the underlying codecs to input mutation race
 conditions, such as allowing a site to mutate a codec input or output while
 the underlying codec is still operating on that data. This concern is mitigated
 by ensuring that input and output interfaces are immutable.
+</div>
 
 Privacy Considerations{#privacy-considerations}
 ===============================================
@@ -6308,6 +6309,7 @@ Additionally, User Agents <em class="rfc2119">MAY</em> implement a "privacy
 budget", which depletes as authors use WebCodecs and other identifying APIs.
 Upon exhaustion of the privacy budget, codec capabilities could be reduced to a
 common baseline or prompt for user approval.
+</div>
 
 Best Practices for Authors Using WebCodecs{#best-practices-developers}
 ======================================================================


### PR DESCRIPTION
- Migrates Makefile from the legacy CSS Spec Preprocessor URL (`https://api.csswg.org/bikeshed/`) to the new W3C spec generator URL (`https://www.w3.org/publications/spec-generator/`)
- Adds `-F type=bikeshed-spec` form param required by the new endpoint
- Fixes missing `</div>` tags in `index.src.html` which were causing the spec generator to die on warnings.