### PR TITLE
Add extended HE-AAC to the AAC WebCodecs Registration

### DIFF
--- a/aac_codec_registration.src.html
+++ b/aac_codec_registration.src.html
@@ -66,7 +66,7 @@ This codec has multiple possible [[WEBCODECS#config-codec-string|codec strings]]
 - `"mp4a.40.5"` — MPEG-4 HE-AAC v1 (AAC LC + SBR)
 - `"mp4a.40.05"` — MPEG-4 HE-AAC v1 (AAC LC + SBR), leading 0 for Aud-OTI compatibility
 - `"mp4a.40.29"` — MPEG-4 HE-AAC v2 (AAC LC + SBR + PS)
-- `"mp4a.40.42"` — Extended HE-AAC (MPEG-D USAC + MPEG-D DRC) as defined in [[iso23003-3]] and [[iso23003-4]]
+- `"mp4a.40.42"` — Extended HE-AAC (xHE-AAC) (MPEG-D USAC + MPEG-D DRC) as defined in [[iso23003-3]] and [[iso23003-4]]
 - `"mp4a.67"` — MPEG-2 AAC LC
 
 EncodedAudioChunk data {#encodedaudiochunk-data}
@@ -79,7 +79,7 @@ to be an ADTS frame, as described in section 1.A.3.2 of [[iso14496-3]].
 If the bitstream is in {{AacBitstreamFormat/aac}} format, the
 {{EncodedAudioChunk/[[internal data]]}} of {{EncodedAudioChunk}}s are expected
 to be a raw AAC frame (syntax element `raw_data_block()`), as described in
-section 4.4.2.1 of [[iso14496-3]]. Extended HE-AAC shall be in {{AacBitstreamFormat/aac}} format.
+section 4.4.2.1 of [[iso14496-3]]. Extended HE-AAC must be in {{AacBitstreamFormat/aac}} format.
 
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================

--- a/aac_codec_registration.src.html
+++ b/aac_codec_registration.src.html
@@ -36,10 +36,22 @@ Markup Shorthands:css no, markdown yes, dfn yes
 <pre class='biblio'>
 {
   "iso14496-3": {
-    "href": "https://www.iso.org/standard/53943.html",
-    "title": "ISO/IEC 14496-3:2009 - Information technology — Coding of audio-visual objects — Part 3: Audio",
+    "href": "https://www.iso.org/standard/76383.html",
+    "title": "ISO/IEC 14496-3:2019 - Information technology — Coding of audio-visual objects — Part 3: Audio",
     "publisher": "ISO",
-    "date": "2009-09"
+    "date": "2019-12"
+  },
+  "iso23003-3": {
+    "href": "https://www.iso.org/standard/76385.html",
+    "title": "ISO/IEC 23003-3:2020 - Information technology — MPEG audio technologies — Part 3: Unified speech and audio coding",
+    "publisher": "ISO",
+    "date": "2020-06"
+  },
+  "iso23003-4": {
+    "href": "https://www.iso.org/standard/89036.html",
+    "title": "ISO/IEC 23003-4:2025 - Information technology — MPEG audio technologies — Part 4: Dynamic range control",
+    "publisher": "ISO",
+    "date": "2025-03"
   }
 }
 </pre>
@@ -54,6 +66,7 @@ This codec has multiple possible [[WEBCODECS#config-codec-string|codec strings]]
 - `"mp4a.40.5"` — MPEG-4 HE-AAC v1 (AAC LC + SBR)
 - `"mp4a.40.05"` — MPEG-4 HE-AAC v1 (AAC LC + SBR), leading 0 for Aud-OTI compatibility
 - `"mp4a.40.29"` — MPEG-4 HE-AAC v2 (AAC LC + SBR + PS)
+- `"mp4a.40.42"` — Extended HE-AAC (MPEG-D USAC + MPEG-D DRC) as defined in [[iso23003-3]] and [[iso23003-4]]
 - `"mp4a.67"` — MPEG-2 AAC LC
 
 EncodedAudioChunk data {#encodedaudiochunk-data}
@@ -66,7 +79,7 @@ to be an ADTS frame, as described in section 1.A.3.2 of [[iso14496-3]].
 If the bitstream is in {{AacBitstreamFormat/aac}} format, the
 {{EncodedAudioChunk/[[internal data]]}} of {{EncodedAudioChunk}}s are expected
 to be a raw AAC frame (syntax element `raw_data_block()`), as described in
-section 4.4.2.1 of [[iso14496-3]].
+section 4.4.2.1 of [[iso14496-3]]. Extended HE-AAC shall be in {{AacBitstreamFormat/aac}} format.
 
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================

--- a/aac_codec_registration.src.html
+++ b/aac_codec_registration.src.html
@@ -84,9 +84,9 @@ section 4.4.2.1 of [[iso14496-3]]. Extended HE-AAC shall be in {{AacBitstreamFor
 AudioDecoderConfig description {#audiodecoderconfig-description}
 ================================================================
 
-If {{AudioDecoderConfig/description}} is present, it is assumed to a
-`AudioSpecificConfig` as defined in [[iso14496-3]] section 1.6.2.1, Table 1.15,
-and the bitstream is assumed to be in {{AacBitstreamFormat/aac}}.
+If {{AudioDecoderConfig/description}} is present, it is assumed to be an
+`AudioSpecificConfig` as defined in [[iso14496-3]] section 1.6.2.1, Table 1.19,
+and the bitstream is assumed to be in {{AacBitstreamFormat/aac}} format.
 
 If the {{AudioDecoderConfig/description}} is not present, the bitstream is
 assumed to be in {{AacBitstreamFormat/adts}} format.


### PR DESCRIPTION
Adds "mp4a.40.42" (Extended HE-AAC) to the list of fully qualified codec strings, along with a note that Extended HE-AAC should use the "aac" bitstream format. Updates the [ISO14496-3] reference to the 2019 edition and adds new bibliographic references for [ISO23003-3] (USAC) and [ISO23003-4] (DRC).

Addresses Issue #929