### PR TITLE
[ImageDecoder] Ensure global promises are marked as handled

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -5441,16 +5441,18 @@ interface ImageDecoder {
         initialized as follows:
         1. Assign a new [=list=] to {{ImageTrackList/[[track list]]}}.
         2. Assign `-1` to {{ImageTrackList/[[selected index]]}}.
+        3. Assign a new promise to {{ImageTrackList/[[ready promise]]}} and [=mark as handled|mark it as handled=].
     9. Assign {{ImageDecoderInit/type}} to {{ImageDecoder/[[type]]}}.
     10. Assign `null` to {{ImageDecoder/[[codec implementation]]}}.
     11. If `init.preferAnimation` [=map/exists=], assign `init.preferAnimation`
         to the {{ImageDecoder/[[prefer animation]]}} internal slot. Otherwise,
         assign 'null' to {{ImageDecoder/[[prefer animation]]}} internal slot.
-    12. Assign a new [=list=] to {{ImageDecoder/[[pending decode promises]]}}.
-    13. Assign `-1` to {{ImageDecoder/[[internal selected track index]]}}.
-    14. Assign `false` to {{ImageDecoder/[[tracks established]]}}.
-    15. Assign `false` to {{ImageDecoder/[[closed]]}}.
-    16. Assign a new [=map=] to {{ImageDecoder/[[progressive frame
+    12. Assign a new promise to {{ImageDecoder/[[completed promise]]}} and [=mark as handled|mark it as handled=].
+    13. Assign a new [=list=] to {{ImageDecoder/[[pending decode promises]]}}.
+    14. Assign `-1` to {{ImageDecoder/[[internal selected track index]]}}.
+    15. Assign `false` to {{ImageDecoder/[[tracks established]]}}.
+    16. Assign `false` to {{ImageDecoder/[[closed]]}}.
+    17. Assign a new [=map=] to {{ImageDecoder/[[progressive frame
         generations]]}}.
     17. If |init|'s {{ImageDecoderInit/data}} member is of type
         {{ReadableStream}}:


### PR DESCRIPTION
There's no reason to spam the global error handler when these promises are unhandled, they are for convienence only.

Fixes #934


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/pull/935.html" title="Last updated on May 4, 2026, 9:49 PM UTC (c35da9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/935/2f46fe3...c35da9a.html" title="Last updated on May 4, 2026, 9:49 PM UTC (c35da9a)">Diff</a>