### PR TITLE
Add PSNR to encoded chunk metadata

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -78,6 +78,12 @@ spec: ECMASCRIPT; urlPrefix: https://tc39.es/ecma262/
       "Youenn Fablet"
     ],
     "status": "ED"
+  },
+  "ISO-29170-1": {
+    "href": "https://www.iso.org/standard/66532.html",
+    "title": "ISO/IEC 29170-1:2017 - Information technology — Advanced image coding and evaluation — Part 1: Guidelines for image quality assessment",
+    "publisher": "ISO",
+    "date": "November 2017"
   }
 }
 </pre>
@@ -1689,9 +1695,15 @@ Algorithms {#videoencoder-algorithms}
             1. Let |alphaSideData| be the encoded alpha data in |output|.
             2. Assign |alphaSideData| to
                 |chunkMetadata|.{{EncodedVideoChunkMetadata/alphaSideData}}.
-        9. Invoke {{VideoEncoder/[[output callback]]}} with |chunk| and
+        9. If |output| contains Peak Signal-to-Noise Ratio (PSNR) metrics:
+            1. Let |psnr| be a new {{YuvVideoPsnr}} dictionary.
+            2. Assign the PSNR value for the Y plane in |output| to |psnr|.{{YuvVideoPsnr/y}}.
+            3. Assign the PSNR value for the U plane in |output| to |psnr|.{{YuvVideoPsnr/u}}.
+            4. Assign the PSNR value for the V plane in |output| to |psnr|.{{YuvVideoPsnr/v}}.
+            5. Assign |psnr| to |chunkMetadata|.{{EncodedVideoChunkMetadata/psnr}}.
+        10. Invoke {{VideoEncoder/[[output callback]]}} with |chunk| and
             |chunkMetadata|.
-  </dd>
+   </dd>
   <dt><dfn>Reset VideoEncoder</dfn> (with |exception|)</dt>
   <dd>
     Run these steps:
@@ -1739,6 +1751,7 @@ dictionary EncodedVideoChunkMetadata {
 dictionary SvcOutputMetadata {
   unsigned long temporalLayerId;
 };
+
 dictionary YuvVideoPsnr {
   double y;
   double u;
@@ -1761,6 +1774,32 @@ dictionary YuvVideoPsnr {
 : <dfn dict-member for=SvcOutputMetadata>temporalLayerId</dfn>
 :: A number that identifies the [=temporal layer=] for the associated
     {{EncodedVideoChunk}}.
+
+: <dfn dict-member for=EncodedVideoChunkMetadata>psnr</dfn>
+:: The Peak Signal-to-Noise Ratio (PSNR) metrics for the encoded frame, if
+    requested and supported. See {{YuvVideoPsnr}}.
+
+
+YuvVideoPsnr dictionary{#yuv-video-psnr}
+----------------------------------------
+The {{YuvVideoPsnr}} dictionary contains Peak Signal-to-Noise Ratio (PSNR)
+values for the Y, U, and V planes, computed in decibels (dB) according to
+[[ISO-29170-1]].
+
+: <dfn dict-member for=YuvVideoPsnr>y</dfn>
+:: The Peak Signal-to-Noise Ratio (PSNR) value for the Y (Luma) plane in dB.
+: <dfn dict-member for=YuvVideoPsnr>u</dfn>
+:: The Peak Signal-to-Noise Ratio (PSNR) value for the U (Chroma) plane in dB.
+: <dfn dict-member for=YuvVideoPsnr>v</dfn>
+:: The Peak Signal-to-Noise Ratio (PSNR) value for the V (Chroma) plane in dB.
+
+    NOTE: PSNR measurements are calculated by comparing the input frame with the
+        reconstructed frame at the configured coded resolution of the encoder.
+        If the input frame's resolution differs from the configured encoder resolution
+        and is scaled during encoding, the scaled version serves as the reference frame
+        for the PSNR calculation.
+
+
 
 
 Configurations{#configurations}

--- a/index.src.html
+++ b/index.src.html
@@ -1733,10 +1733,16 @@ dictionary EncodedVideoChunkMetadata {
   VideoDecoderConfig decoderConfig;
   SvcOutputMetadata svc;
   BufferSource alphaSideData;
+  YuvVideoPsnr psnr;
 };
 
 dictionary SvcOutputMetadata {
   unsigned long temporalLayerId;
+};
+dictionary YuvVideoPsnr {
+  double y;
+  double u;
+  double v;
 };
 </xmp>
 
@@ -2464,6 +2470,7 @@ VideoEncoderEncodeOptions{#video-encoder-options}
 <xmp class='idl'>
 dictionary VideoEncoderEncodeOptions {
   boolean keyFrame = false;
+  boolean generatePsnr = false;
 };
 </xmp>
 
@@ -2477,7 +2484,14 @@ NOTE: Codec-specific extensions to {{VideoEncoderEncodeOptions}} are described i
     <em class="rfc2119">MUST</em> be encoded as a key frame. A value of `false`
     indicates that the User Agent has flexibility to decide whether the frame
     will be encoded as a [=key frame=].
-  </dd>
+</dd>
+<dt><dfn dict-member for=VideoEncoderEncodeOptions>generatePsnr</dfn></dt>
+<dd>
+    A value of `true` indicates that the Encoder will attempt to compute PSNR
+    metrics for the encoded frame and provide them as part of the
+    {{EncodedVideoChunkMetadata}}. Note that not all encoders supports this, so
+    the metrics is provided on a best-effort basis.
+</dd>
 </dl>
 
 


### PR DESCRIPTION
This adds the ability to request PSNR measurements as well as the signal back (if available) on the encoded chunk metadata.

Fixes #937


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sprangerik/webcodecs/pull/938.html" title="Last updated on Jun 1, 2026, 3:47 PM UTC (904163e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/938/1046684...sprangerik:904163e.html" title="Last updated on Jun 1, 2026, 3:47 PM UTC (904163e)">Diff</a>