### PR TITLE
Update the algorithm to ensure that the config is set as part of a successful configure

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -922,11 +922,10 @@ Algorithms {#videodecoder-algorithms}
 
         5. If {{VideoDecoderConfig/colorSpace}} [=map/exists=] in the
             {{VideoDecoder/[[active decoder config]]}}, assign its value to
-            |colorSpace|. In that case, if some members of
-            {{VideoDecoder/[[active decoder config]]}}'s
-            {{VideoDecoderConfig/colorSpace}} are null, the User Agent MAY use
-            codec implementation detected values for those members.
-            FIXME: Properly specify the case of missing fields.
+            |colorSpace|. In that case, User Agents MAY replace `null` members
+            of |colorSpace| with the corresponding values detected by the codec
+            implementation.
+            FIXME: Properly specify the case of `null` members.
         6. Assign the values of {{VideoDecoderConfig/rotation}} and
             {{VideoDecoderConfig/flip}} to |rotation| and |flip| respectively.
         7. Let |frame| be the result of running the [=Create a VideoFrame=]

--- a/index.src.html
+++ b/index.src.html
@@ -741,7 +741,8 @@ Methods {#videodecoder-methods}
         3. If needed, assign {{VideoDecoder/[[codec implementation]]}} with an
             implementation supporting |config|.
         4. Configure {{VideoDecoder/[[codec implementation]]}} with |config|.
-        5. [=queue a task=] to run the following steps:
+        5. Assign |config| to {{VideoDecoder/[[active decoder config]]}}.
+        6. [=queue a task=] to run the following steps:
             1. Assign `false` to {{VideoDecoder/[[message queue blocked]]}}.
             2. [=Queue a task=] to [=Process the control message queue=].
     3. Return `"processed"`.
@@ -921,7 +922,11 @@ Algorithms {#videodecoder-algorithms}
 
         5. If {{VideoDecoderConfig/colorSpace}} [=map/exists=] in the
             {{VideoDecoder/[[active decoder config]]}}, assign its value to
-            |colorSpace|.
+            |colorSpace|. In that case, if some members of
+            {{VideoDecoder/[[active decoder config]]}}'s
+            {{VideoDecoderConfig/colorSpace}} are null, the User Agent MAY use
+            codec implementation detected values for those members.
+            FIXME: Properly specify the case of missing fields.
         6. Assign the values of {{VideoDecoderConfig/rotation}} and
             {{VideoDecoderConfig/flip}} to |rotation| and |flip| respectively.
         7. Let |frame| be the result of running the [=Create a VideoFrame=]
@@ -1100,7 +1105,8 @@ Methods {#audioencoder-methods}
         3. If needed, assign {{AudioEncoder/[[codec implementation]]}} with an
             implementation supporting |config|.
         4. Configure {{AudioEncoder/[[codec implementation]]}} with |config|.
-        5. [=queue a task=] to run the following steps:
+        5. Assign |config| to {{AudioEncoder/[[active encoder config]]}}.
+        6. [=queue a task=] to run the following steps:
             1. Assign `false` to {{AudioEncoder/[[message queue blocked]]}}.
             2. [=Queue a task=] to [=Process the control message queue=].
     3. Return `"processed"`.
@@ -1481,7 +1487,8 @@ Methods {#videoencoder-methods}
         3. If needed, assign {{VideoEncoder/[[codec implementation]]}} with an
             implementation supporting |config|.
         4. Configure {{VideoEncoder/[[codec implementation]]}} with |config|.
-        5. [=queue a task=] to run the following steps:
+        5. Assign |config| to {{VideoEncoder/[[active encoder config]]}}.
+        6. [=queue a task=] to run the following steps:
             1. Assign `false` to {{VideoEncoder/[[message queue blocked]]}}.
             2. [=Queue a task=] to [=Process the control message queue=].
     3. Return `"processed"`.


### PR DESCRIPTION
In the video output algorithm section, we now mention that partial config color space can be augmented with codec implementation detected color space. As a fly-by fix, we also make sure that the encoders get their active config set to the config given to configure.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/webcodecs/pull/943.html" title="Last updated on Jul 8, 2026, 1:27 PM UTC (55ed6e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webcodecs/943/0426d1d...youennf:55ed6e9.html" title="Last updated on Jul 8, 2026, 1:27 PM UTC (55ed6e9)">Diff</a>