### PR TITLE
Specify audio codec registration priming sample handling (#944)

### DIFF
--- a/aac_codec_registration.src.html
+++ b/aac_codec_registration.src.html
@@ -104,6 +104,24 @@ NOTE: Once the initialization has succeeded, any AAC packet can be decoded at
     any time without error, but this might not result in the expected audio
     output.
 
+Priming Samples {#priming-samples}
+==================================
+
+Standard AAC bitstreams do not typically convey priming samples, and
+{{AudioDecoder}}'s {{AudioDecoder/[[priming samples to discard]]}} internal slot
+is initialized to `0` upon configuration.
+
+If the initial {{EncodedAudioChunk}} following configuration or reset conveys
+in-band encoder delay information (for example, through an encoder
+identification string in an extension payload fill element),
+{{AudioDecoder/[[priming samples to discard]]}} <em class="rfc2119">MAY</em> be
+set to that number of [=priming samples=].
+
+Subsequent {{EncodedAudioChunk}}s <em class="rfc2119">MUST NOT</em> update
+{{AudioDecoder/[[priming samples to discard]]}}. During an active decoding
+session, {{AudioDecoder/[[priming samples to discard]]}} is only re-initialized
+following a call to {{AudioDecoder/reset()}} or {{AudioDecoder/configure()}}.
+
     AudioEncoderConfig extensions {#audioencoderconfig-extensions}
     ==============================================================
 

--- a/codec_registry.src.html
+++ b/codec_registry.src.html
@@ -78,6 +78,7 @@ or by the party requesting the candidate registration) that meets the following 
     4. Expectations for {{EncodedAudioChunk}} or {{EncodedVideoChunk}}
         {{EncodedVideoChunk/[[type]]}}.
 4. Where applicable, a registration specification may include a section describing [=partial dictionary|extensions to the dictionaries=] used in the `configure()`, `decode()` and `encode()` methods of the decoder and encoder interfaces (e.g., {{AudioDecoderConfig}}, {{VideoDecoderConfig}}, {{AudioEncoderConfig}}, {{VideoEncoderConfig}}, {{VideoEncoderEncodeOptions}}).
+5. Where applicable, an audio codec registration specification SHOULD describe how {{AudioDecoder}}'s {{AudioDecoder/[[priming samples to discard]]}} internal slot is initialized from the {{AudioDecoderConfig/description}} and updated from decoded chunks. If unspecified for an audio codec, the slot is initialized to `0` and not updated.
 
 Once consensus is reached by the Working Group, the registry editors will review and merge the pull request.
 

--- a/mp3_codec_registration.src.html
+++ b/mp3_codec_registration.src.html
@@ -80,6 +80,24 @@ NOTE: Once the initialization has succeeded, any mp3 packet can be decoded at
     any time without error, but this might not result in the expected audio
     output.
 
+Priming Samples {#priming-samples}
+==================================
+
+{{AudioDecoder}}'s {{AudioDecoder/[[priming samples to discard]]}} internal slot
+is initialized to `0` upon configuration.
+
+If the initial {{EncodedAudioChunk}} following configuration or reset contains
+an Info or Xing header frame specifying encoder delay,
+{{AudioDecoder/[[priming samples to discard]]}} is set to that number of
+[=priming samples=].
+
+If a subsequent {{EncodedAudioChunk}} contains an Info or Xing header frame (such
+as in a concatenated MP3 stream or internet radio broadcast), it <em
+class="rfc2119">MUST NOT</em> update {{AudioDecoder/[[priming samples to
+discard]]}}. During an active decoding session, {{AudioDecoder/[[priming samples
+to discard]]}} is only re-initialized following a call to
+{{AudioDecoder/reset()}} or {{AudioDecoder/configure()}}.
+
 Privacy Considerations {#privacy-considerations}
 ==========================================================================
 

--- a/opus_codec_registration.src.html
+++ b/opus_codec_registration.src.html
@@ -90,6 +90,11 @@ Opus is always "{{EncodedAudioChunkType/key}}".
 NOTE: Once the initialization has succeeded, any packet can be decoded at any
 time without error, but this might not result in the expected audio output.
 
+Priming Samples {#priming-samples}
+==================================
+
+The `Pre-skip` field in the Identification Header (see section 5.1 of [[OPUS-IN-OGG]]), if present in {{AudioDecoderConfig/description}}, specifies the initial value for {{AudioDecoder}}'s {{AudioDecoder/[[priming samples to discard]]}} internal slot. If {{AudioDecoderConfig/description}} is not present, {{AudioDecoder/[[priming samples to discard]]}} is initialized to `0`. Decoded {{EncodedAudioChunk}}s do not convey additional discard information.
+
 AudioEncoderConfig extensions {#audioencoderconfig-extensions}
 =============================================================
 


### PR DESCRIPTION
Update codec registry entry requirements and add Priming Samples sections for Opus, MP3, and AAC describing how [[priming samples to discard]] is initialized and updated.

This is done as a stacked PR to avoid registry bikeshed breakages due to the new internal slot definition.

See #944
See #626
